### PR TITLE
Add IHP SG13CMOS5L Technology

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ BlenderGDS enables semiconductor layout visualization by importing GDSII files i
 
 ## Supported PDKs
 
-* IHP Open PDK (SG13G2)
+* IHP Open PDK (SG13G2 & CMOS5L)
 * SkyWater SKY130 PDK
 * GlobalFoundries GF180MCU PDK
 

--- a/import_gdsii/__init__.py
+++ b/import_gdsii/__init__.py
@@ -42,6 +42,11 @@ PDK_CONFIGS = {
         'config_path': 'configs/ihp-sg13g2.yaml',
         'color_path': 'configs/colors/ihp-sg13g2/'
     },
+    'IHP_SG13CMOS5L': {
+        'name': 'IHP Open PDK (SG13CMOS5L)',
+        'config_path': 'configs/ihp-sg13cmos5l.yaml',
+        'color_path': 'configs/colors/ihp-sg13cmos5l/'
+    },
     'SKY130': {
         'name': 'SkyWater SKY130 PDK',
         'config_path': 'configs/sky130.yaml',
@@ -286,6 +291,7 @@ class GDSIIPreImportDialog(bpy.types.Operator):
         description="Process Design Kit to use for layer stack",
         items=[
             ('IHP_SG13G2', "IHP Open PDK SG13G2", "IHP SG13G2 130nm BiCMOS process"),
+            ('IHP_SG13CMOS5L', "IHP Open PDK SG13CMOS5L", "IHP SG13CMOS5L 130nm CMOS5L process"),
             ('SKY130', "SkyWater SKY130 PDK", "SkyWater SKY130 130nm process"),
             ('GF180MCU', "GlobalFoundries GF180MCU PDK", "GlobalFoundries GF180MCU 180nm process"),
         ],

--- a/import_gdsii/configs/colors/ihp-sg13cmos5l/fancy.yaml
+++ b/import_gdsii/configs/colors/ihp-sg13cmos5l/fancy.yaml
@@ -1,0 +1,89 @@
+# SPDX-FileCopyrightText: 2026 aesc silicon
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: Fancy
+description: Fancy color scheme - premium tech aesthetic
+layers:
+  # Active regions - deep teal/cyan (sophisticated, tech-forward)
+  Activ:
+    color: [0.15, 0.75, 0.70, 0.90]
+  ActivFiller:
+    color: [0.15, 0.75, 0.70, 0.60]
+
+  # Gate poly - deep purple (elegant contrast)
+  GatPoly:
+    color: [0.45, 0.25, 0.75, 0.95]
+  GatPolyFiller:
+    color: [0.45, 0.25, 0.75, 0.60]
+
+  # NWell - warm amber/gold (subtle accent)
+  NWell:
+    color: [0.85, 0.65, 0.30, 0.60]
+
+  # Contacts - bright copper/rose gold
+  Cont:
+    color: [0.90, 0.55, 0.40, 1.0]
+    metallic: 0.8
+
+  # Vias - graduated warm metallics (copper to bronze)
+  Via1:
+    color: [0.85, 0.50, 0.35, 1.0]
+    metallic: 0.8
+  Via2:
+    color: [0.80, 0.52, 0.38, 1.0]
+    metallic: 0.8
+  Via3:
+    color: [0.75, 0.54, 0.40, 1.0]
+    metallic: 0.8
+
+  TopVia1:
+    color: [0.82, 0.60, 0.45, 1.0]
+    metallic: 0.8
+
+  # Metal layers - cool blue gradient (sleek, modern)
+  Metal1:
+    color: [0.30, 0.50, 0.75, 1.0]
+    metallic: 0.8
+    roughness: 0.3
+  Metal1Filler:
+    color: [0.30, 0.50, 0.75, 0.65]
+    metallic: 0.8
+    roughness: 0.3
+
+  Metal2:
+    color: [0.35, 0.55, 0.80, 1.0]
+    metallic: 0.8
+    roughness: 0.3
+  Metal2Filler:
+    color: [0.35, 0.55, 0.80, 0.65]
+    metallic: 0.8
+    roughness: 0.3
+
+  Metal3:
+    color: [0.40, 0.60, 0.85, 1.0]
+    metallic: 0.8
+    roughness: 0.3
+  Metal3Filler:
+    color: [0.40, 0.60, 0.85, 0.65]
+    metallic: 0.8
+    roughness: 0.3
+
+  Metal4:
+    color: [0.50, 0.68, 0.90, 1.0]
+    metallic: 0.8
+    roughness: 0.3
+  Metal4Filler:
+    color: [0.50, 0.68, 0.90, 0.65]
+    metallic: 0.8
+    roughness: 0.3
+
+  # Top metals - bright cyan (hero layers)
+  TopMetal1:
+    color: [0.60, 0.75, 0.95, 1.0]
+    metallic: 0.8
+    roughness: 0.3
+  TopMetal1Filler:
+    color: [0.60, 0.75, 0.95, 0.70]
+    metallic: 0.8
+    roughness: 0.3

--- a/import_gdsii/configs/colors/ihp-sg13cmos5l/marketing-gold.yaml
+++ b/import_gdsii/configs/colors/ihp-sg13cmos5l/marketing-gold.yaml
@@ -1,0 +1,86 @@
+# SPDX-FileCopyrightText: 2026 aesc silicon
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: Marketing (Gold)
+description: Marketing color scheme with gold
+layers:
+  # Silicon / Devices (enhanced but plausible)
+  Activ:
+    color: [0.20, 0.80, 0.30, 0.8]
+  ActivFiller:
+    color: [0.20, 0.80, 0.30, 0.8]
+
+  GatPoly:
+    color: [1.00, 0.30, 0.30, 0.9]
+  GatPolyFiller:
+    color: [1.00, 0.30, 0.30, 0.9]
+
+  NWell:
+    color: [0.30, 0.50, 1.00, 0.8]
+
+  # Gold vias (warm, luxurious gradient)
+  Cont:
+    color: [0.98, 0.78, 0.26, 1.0]
+    metallic: 0.8
+
+  Via1:
+    color: [0.94, 0.72, 0.24, 1.0]
+    metallic: 0.8
+  Via2:
+    color: [0.92, 0.69, 0.23, 1.0]
+    metallic: 0.8
+  Via3:
+    color: [0.90, 0.66, 0.22, 1.0]
+    metallic: 0.8
+
+  TopVia1:
+    color: [0.86, 0.60, 0.20, 1.0]
+    metallic: 0.8
+
+  # Aluminum / platinum-like metals (cool, clean with subtle warmth)
+  Metal1:
+    color: [0.49, 0.49, 0.52, 1.0]
+    metallic: 0.8
+    roughness: 0.3
+  Metal1Filler:
+    color: [0.49, 0.49, 0.52, 0.65]
+    metallic: 0.8
+    roughness: 0.3
+
+  Metal2:
+    color: [0.57, 0.58, 0.61, 1.0]
+    metallic: 0.8
+    roughness: 0.3
+  Metal2Filler:
+    color: [0.57, 0.58, 0.61, 0.65]
+    metallic: 0.8
+    roughness: 0.3
+
+  Metal3:
+    color: [0.65, 0.66, 0.69, 1.0]
+    metallic: 0.8
+    roughness: 0.3
+  Metal3Filler:
+    color: [0.65, 0.66, 0.69, 0.65]
+    metallic: 0.8
+    roughness: 0.3
+
+  Metal4:
+    color: [0.73, 0.74, 0.77, 1.0]
+    metallic: 0.8
+    roughness: 0.3
+  Metal4Filler:
+    color: [0.73, 0.74, 0.77, 0.65]
+    metallic: 0.8
+    roughness: 0.3
+
+  # Hero top metals (bright, premium finish)
+  TopMetal1:
+    color: [0.81, 0.82, 0.85, 1.0]
+    metallic: 0.8
+    roughness: 0.3
+  TopMetal1Filler:
+    color: [0.81, 0.82, 0.85, 0.70]
+    metallic: 0.8
+    roughness: 0.3

--- a/import_gdsii/configs/colors/ihp-sg13cmos5l/marketing.yaml
+++ b/import_gdsii/configs/colors/ihp-sg13cmos5l/marketing.yaml
@@ -1,0 +1,86 @@
+# SPDX-FileCopyrightText: 2026 aesc silicon
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: Marketing
+description: Marketing color scheme
+layers:
+  # Silicon / Devices (enhanced but plausible)
+  Activ:
+    color: [0.40, 0.55, 0.30, 0.90]
+  ActivFiller:
+    color: [0.40, 0.55, 0.30, 0.55]
+
+  GatPoly:
+    color: [0.22, 0.22, 0.20, 0.95]
+  GatPolyFiller:
+    color: [0.22, 0.22, 0.20, 0.60]
+
+  NWell:
+    color: [0.35, 0.55, 0.65, 0.55]
+
+  # Tungsten (dark contrast backbone)
+  Cont:
+    color: [0.35, 0.37, 0.40, 1.0]
+    metallic: 0.8
+
+  Via1:
+    color: [0.38, 0.40, 0.43, 1.0]
+    metallic: 0.8
+  Via2:
+    color: [0.40, 0.42, 0.45, 1.0]
+    metallic: 0.8
+  Via3:
+    color: [0.42, 0.44, 0.47, 1.0]
+    metallic: 0.8
+
+  TopVia1:
+    color: [0.46, 0.48, 0.51, 1.0]
+    metallic: 0.8
+
+  # Aluminum stack (cool silver gradient with subtle warmth)
+  Metal1:
+    color: [0.61, 0.62, 0.64, 1.0]
+    metallic: 0.8
+    roughness: 0.3
+  Metal1Filler:
+    color: [0.61, 0.62, 0.64, 0.65]
+    metallic: 0.8
+    roughness: 0.3
+
+  Metal2:
+    color: [0.67, 0.68, 0.70, 1.0]
+    metallic: 0.8
+    roughness: 0.3
+  Metal2Filler:
+    color: [0.67, 0.68, 0.70, 0.65]
+    metallic: 0.8
+    roughness: 0.3
+
+  Metal3:
+    color: [0.73, 0.74, 0.76, 1.0]
+    metallic: 0.8
+    roughness: 0.3
+  Metal3Filler:
+    color: [0.73, 0.74, 0.76, 0.65]
+    metallic: 0.8
+    roughness: 0.3
+
+  Metal4:
+    color: [0.79, 0.80, 0.82, 1.0]
+    metallic: 0.8
+    roughness: 0.3
+  Metal4Filler:
+    color: [0.79, 0.80, 0.82, 0.65]
+    metallic: 0.8
+    roughness: 0.3
+
+  # Hero layers (bright, premium aluminum)
+  TopMetal1:
+    color: [0.84, 0.85, 0.87, 1.0]
+    metallic: 0.8
+    roughness: 0.3
+  TopMetal1Filler:
+    color: [0.84, 0.85, 0.87, 0.70]
+    metallic: 0.8
+    roughness: 0.3

--- a/import_gdsii/configs/colors/ihp-sg13cmos5l/realistic.yaml
+++ b/import_gdsii/configs/colors/ihp-sg13cmos5l/realistic.yaml
@@ -1,0 +1,85 @@
+# SPDX-FileCopyrightText: 2026 aesc silicon
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: Realistic
+description: Realistic color scheme
+layers:
+  Activ:
+    color: [0.35, 0.45, 0.25, 0.85]
+  ActivFiller:
+    color: [0.35, 0.45, 0.25, 0.85]
+
+  GatPoly:
+    color: [0.18, 0.18, 0.16, 0.95]
+  GatPolyFiller:
+    color: [0.18, 0.18, 0.16, 0.95]
+
+  NWell:
+    color: [0.30, 0.45, 0.55, 0.65]
+
+  # Tungsten contacts & vias (dark, slightly bluish steel)
+  Cont:
+    color: [0.42, 0.44, 0.46, 1.0]
+    metallic: 0.8
+
+  Via1:
+    color: [0.45, 0.47, 0.50, 1.0]
+    metallic: 0.8
+  Via2:
+    color: [0.47, 0.49, 0.52, 1.0]
+    metallic: 0.8
+  Via3:
+    color: [0.49, 0.51, 0.54, 1.0]
+    metallic: 0.8
+
+  TopVia1:
+    color: [0.53, 0.55, 0.58, 1.0]
+    metallic: 0.8
+
+  # Aluminum metal stack (slightly warmer tone, progressively brighter)
+  Metal1:
+    color: [0.63, 0.64, 0.65, 1.0]
+    metallic: 0.8
+    roughness: 0.3
+  Metal1Filler:
+    color: [0.63, 0.64, 0.65, 1.0]
+    metallic: 0.8
+    roughness: 0.3
+
+  Metal2:
+    color: [0.67, 0.68, 0.69, 1.0]
+    metallic: 0.8
+    roughness: 0.3
+  Metal2Filler:
+    color: [0.67, 0.68, 0.69, 1.0]
+    metallic: 0.8
+    roughness: 0.3
+
+  Metal3:
+    color: [0.71, 0.72, 0.73, 1.0]
+    metallic: 0.8
+    roughness: 0.3
+  Metal3Filler:
+    color: [0.71, 0.72, 0.73, 1.0]
+    metallic: 0.8
+    roughness: 0.3
+
+  Metal4:
+    color: [0.75, 0.76, 0.77, 1.0]
+    metallic: 0.8
+    roughness: 0.3
+  Metal4Filler:
+    color: [0.75, 0.76, 0.77, 1.0]
+    metallic: 0.8
+    roughness: 0.3
+
+  # Thick top aluminum (cleaner, brighter)
+  TopMetal1:
+    color: [0.79, 0.80, 0.81, 1.0]
+    metallic: 0.8
+    roughness: 0.3
+  TopMetal1Filler:
+    color: [0.79, 0.80, 0.81, 1.0]
+    metallic: 0.8
+    roughness: 0.3

--- a/import_gdsii/configs/ihp-sg13cmos5l.yaml
+++ b/import_gdsii/configs/ihp-sg13cmos5l.yaml
@@ -1,0 +1,111 @@
+# SPDX-FileCopyrightText: 2026 aesc silicon
+#
+# SPDX-License-Identifier: Apache-2.0
+
+Activ:
+  index: 1
+  type: 0
+  z: -0.3995
+  height: 0.40
+ActivFiller:
+  index: 1
+  type: 22
+  purpose: filler
+  z: -0.3995
+  height: 0.40
+GatPoly:
+  index: 5
+  type: 0
+  z: -0.399
+  height: 0.40
+GatPolyFiller:
+  index: 5
+  type: 22
+  purpose: filler
+  z: -0.399
+  height: 0.40
+NWell:
+  index: 31
+  type: 0
+  z: -0.4
+  height: 0.40
+Cont:
+  index: 6
+  type: 0
+  z: 0.00
+  height: 0.64
+Metal1:
+  index: 8
+  type: 0
+  z: 0.640
+  height: 0.40
+Metal1Filler:
+  index: 8
+  type: 22
+  purpose: filler
+  z: 0.640
+  height: 0.40
+Via1:
+  index: 19
+  type: 0
+  z: 1.06
+  height: 0.54
+Metal2:
+  index: 10
+  type: 0
+  z: 1.600
+  height: 0.49
+Metal2Filler:
+  index: 10
+  type: 22
+  purpose: filler
+  z: 1.600
+  height: 0.49
+Via2:
+  index: 29
+  type: 0
+  z: 2.09
+  height: 0.54
+Metal3:
+  index: 30
+  type: 0
+  z: 2.63
+  height: 0.49
+Metal3Filler:
+  index: 30
+  type: 22
+  purpose: filler
+  z: 2.63
+  height: 0.49
+Via3:
+  index: 49
+  type: 0
+  z: 3.12
+  height: 0.54
+Metal4:
+  index: 50
+  type: 0
+  z: 3.66
+  height: 0.49
+Metal4Filler:
+  index: 50
+  type: 22
+  purpose: filler
+  z: 3.66
+  height: 0.49
+TopVia1:
+  index: 125
+  type: 0
+  z: 4.15
+  height: 0.85
+TopMetal1:
+  index: 126
+  type: 0
+  z: 5.00
+  height: 2.00
+TopMetal1Filler:
+  index: 126
+  type: 22
+  purpose: filler
+  z: 5.00
+  height: 2.00


### PR DESCRIPTION
This tech is similar to the  SG13G2, but only has 5 metal layers. It's missing Metal5 and TopMetal2 and TopMetal1 is located lower.