### PR TITLE
import_gdsii: Fix klayout import

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ BlenderGDS enables semiconductor layout visualization by importing GDSII files i
 BlenderGDS requires the following Python packages:
 
 * `gdstk` - GDSII file handling
+* `klayout` - Layer merging to eliminate Cycles rendering artifacts
 * `numpy` - Numerical operations
 * `PyYAML` - Configuration file parsing
 

--- a/import_gdsii/__init__.py
+++ b/import_gdsii/__init__.py
@@ -552,7 +552,7 @@ class ImportGDSII(bpy.types.Operator, ImportHelper):
 
     def execute(self, context):
         if not DEPENDENCIES_OK:
-            self.report({'ERROR'}, f"Missing dependencies: {IMPORT_ERROR}. Install gdstk, numpy, and PyYAML.")
+            self.report({'ERROR'}, f"Missing dependencies: {IMPORT_ERROR}. Install gdstk, klayout, numpy and PyYAML.")
             return {'CANCELLED'}
 
         return self.import_gdsii(context, self.filepath)


### PR DESCRIPTION
The klayout import was mentioned in two locations. Add as dep to README and to error message when one import failed.