### PR TITLE
Address Feedback from Blender

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ BlenderGDS requires **Blender 4.2 or later**. All Python dependencies (`gdstk`, 
 ### Installing from Blender Extensions
 
 1. In Blender, open **Edit → Preferences → Get Extensions**
-2. Search for **BlenderGDS**
+2. Search for **GDSII Importer**
 3. Click **Install**
 
 The extension is now active. No restart needed.

--- a/import_gdsii/__init__.py
+++ b/import_gdsii/__init__.py
@@ -3,9 +3,9 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 bl_info = {
-    "name": "GDSII Importer with PDK Support",
+    "name": "GDSII Importer",
     "author": "aesc silicon",
-    "version": (1, 0, 0),
+    "version": (1, 0, 1),
     "blender": (3, 4, 0),
     "location": "File > Import",
     "description": "Import GDSII files with PDK layer stack support",
@@ -17,21 +17,15 @@ bl_info = {
 import bpy
 from bpy.props import StringProperty, BoolProperty, FloatProperty, EnumProperty
 from bpy_extras.io_utils import ImportHelper
+import numpy as np
 import os
 import tempfile
 from pathlib import Path
-
-# Blender on Windows bundles stubs for some packages that shadow the real wheels.
-# Evict them from the module cache so the extension wheels are imported instead.
-import sys
-for _mod in ('yaml', '_yaml', 'gdstk', 'klayout', 'klayout.db'):
-    sys.modules.pop(_mod, None)
 
 # Try to import required packages
 try:
     import gdstk
     import klayout.db as db
-    import numpy as np
     import yaml
     DEPENDENCIES_OK = True
 except ImportError as e:
@@ -558,7 +552,7 @@ class ImportGDSII(bpy.types.Operator, ImportHelper):
 
     def execute(self, context):
         if not DEPENDENCIES_OK:
-            self.report({'ERROR'}, f"Missing dependencies: {IMPORT_ERROR}. Install gdstk, klayout, numpy and PyYAML.")
+            self.report({'ERROR'}, f"Missing dependencies: {IMPORT_ERROR}. Install gdstk, klayout and PyYAML.")
             return {'CANCELLED'}
 
         return self.import_gdsii(context, self.filepath)
@@ -717,7 +711,6 @@ def register():
     # Check dependencies on registration
     if not DEPENDENCIES_OK:
         print(f"⚠ GDSII Importer: Missing dependencies - {IMPORT_ERROR}")
-        print("  Install with: pip install gdstk numpy pyyaml --break-system-packages")
 
     register_properties()
 

--- a/import_gdsii/blender_manifest.toml
+++ b/import_gdsii/blender_manifest.toml
@@ -5,15 +5,17 @@
 schema_version = "1.0.0"
 
 id = "import_gdsii"
-version = "1.0.0"
-name = "BlenderGDS"
+version = "1.0.1"
+name = "GDSII Importer"
 tagline = "GDSII importer with PDK layer stack support"
 maintainer = "aesc silicon"
 type = "add-on"
 
 blender_version_min = "4.2.0"
 
-license = ["SPDX:GPL-3.0-or-later"]
+license = ['SPDX:GPL-3.0-or-later']
+
+platforms = ["linux-x64", "windows-x64", "macos-arm64"]
 
 tags = ["Import-Export"]
 

--- a/scripts/build_extension.py
+++ b/scripts/build_extension.py
@@ -25,15 +25,17 @@ ADDON_DIR = REPO_DIR / "import_gdsii"
 WHEELS_DIR = ADDON_DIR / "wheels"
 MANIFEST_PATH = ADDON_DIR / "blender_manifest.toml"
 
-PACKAGES = ["gdstk", "numpy", "klayout", "PyYAML"]
-PYTHON_VERSION = "3.11"
+PACKAGES = ["gdstk", "klayout", "PyYAML"]
+
+# Blender 4.2/4.3 uses Python 3.11, Blender 4.4+ uses Python 3.13.
+# Downloading wheels for both ensures compatibility across all supported versions.
+PYTHON_VERSIONS = ["3.11", "3.13"]
 
 # One entry per (OS, architecture) combination that Blender supports.
 PLATFORMS = [
     "manylinux_2_28_x86_64",   # Linux x86-64
     "win_amd64",                # Windows x86-64
     "macosx_11_0_arm64",        # macOS Apple Silicon
-    "macosx_10_9_x86_64",       # macOS Intel
 ]
 
 MANIFEST_TEMPLATE = """\
@@ -44,8 +46,8 @@ MANIFEST_TEMPLATE = """\
 schema_version = "1.0.0"
 
 id = "import_gdsii"
-version = "1.0.0"
-name = "BlenderGDS"
+version = "1.0.1"
+name = "GDSII Importer"
 tagline = "GDSII importer with PDK layer stack support"
 maintainer = "aesc silicon"
 type = "add-on"
@@ -53,6 +55,8 @@ type = "add-on"
 blender_version_min = "4.2.0"
 
 license = ['SPDX:GPL-3.0-or-later']
+
+platforms = ["linux-x64", "windows-x64", "macos-arm64"]
 
 tags = ["Import-Export"]
 
@@ -68,22 +72,23 @@ def download_wheels() -> None:
         shutil.rmtree(WHEELS_DIR)
     WHEELS_DIR.mkdir()
 
-    for platform in PLATFORMS:
-        print(f"\nDownloading wheels for {platform}...")
-        try:
-            subprocess.run(
-                [
-                    sys.executable, "-m", "pip", "download",
-                    "--python-version", PYTHON_VERSION,
-                    "--only-binary=:all:",
-                    "--platform", platform,
-                    "--dest", str(WHEELS_DIR),
-                    *PACKAGES,
-                ],
-                check=True,
-            )
-        except subprocess.CalledProcessError:
-            print(f"  Warning: some packages could not be downloaded for {platform}")
+    for python_version in PYTHON_VERSIONS:
+        for platform in PLATFORMS:
+            print(f"\nDownloading wheels for {platform} (Python {python_version})...")
+            try:
+                subprocess.run(
+                    [
+                        sys.executable, "-m", "pip", "download",
+                        "--python-version", python_version,
+                        "--only-binary=:all:",
+                        "--platform", platform,
+                        "--dest", str(WHEELS_DIR),
+                        *PACKAGES,
+                    ],
+                    check=True,
+                )
+            except subprocess.CalledProcessError:
+                print(f"  Warning: some packages could not be downloaded for {platform} (Python {python_version})")
 
 
 def write_manifest() -> None:
@@ -103,6 +108,7 @@ def build(blender_exe: str) -> None:
             blender_exe, "--command", "extension", "build",
             "--source-dir", str(ADDON_DIR),
             "--output-dir", str(REPO_DIR),
+            "--split-platforms",
         ],
         check=True,
     )


### PR DESCRIPTION
- Fixed extension compatibility with Blender 4.4 (Python 3.13)
- Added platform-split packages — each OS now only receives the wheels it needs
- Removed bundled numpy (already included with Blender)
- Removed sys.modules workaround