### PR TITLE
Add Luxtelligence LNOI400 PDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ BlenderGDS enables semiconductor layout visualization by importing GDSII files i
 * SkyWater SKY130 PDK
 * GlobalFoundries GF180MCU PDK
 * SiEPIC EBeam PDK (silicon photonics)
+* Luxtelligence LNOI400 PDK (thin-film lithium niobate photonics)
 
 ## Installation
 

--- a/import_gdsii/__init__.py
+++ b/import_gdsii/__init__.py
@@ -56,6 +56,11 @@ PDK_CONFIGS = {
         'config_path': 'configs/siepic.yaml',
         'color_path': 'configs/colors/siepic/'
     },
+    'LNOI400': {
+        'name': 'Luxtelligence LNOI400 PDK',
+        'config_path': 'configs/lnoi400.yaml',
+        'color_path': 'configs/colors/lnoi400/'
+    },
 }
 
 
@@ -343,6 +348,7 @@ class GDSIIPreImportDialog(bpy.types.Operator):
             ('SKY130', "SkyWater SKY130 PDK", "SkyWater SKY130 130nm process"),
             ('GF180MCU', "GlobalFoundries GF180MCU PDK", "GlobalFoundries GF180MCU 180nm process"),
             ('SIEPIC_EBEAM', "SiEPIC EBeam PDK", "SiEPIC EBeam silicon photonics PDK (220 nm SOI)"),
+            ('LNOI400', "Luxtelligence LNOI400 PDK", "Luxtelligence LNOI400 thin-film lithium niobate (X-cut, 400 nm LN, 200 nm etch) photonics PDK"),
         ],
         default='IHP_SG13G2',
     )

--- a/import_gdsii/configs/colors/lnoi400/fancy.yaml
+++ b/import_gdsii/configs/colors/lnoi400/fancy.yaml
@@ -1,0 +1,54 @@
+# SPDX-FileCopyrightText: 2026 Tom <tom@flexcompute.com>
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+name: Fancy
+description: Fancy color scheme - vivid flat aesthetic
+layers:
+  # LN ridge — vivid violet (matches KLayout default #ca84f5)
+  LN_RIDGE:
+    color: [0.79, 0.52, 0.96, 1.0]
+    metallic: 0.0
+    roughness: 1.0
+
+  # LN slab — deeper purple (matches #875dd4)
+  LN_SLAB:
+    color: [0.53, 0.36, 0.83, 1.0]
+    metallic: 0.0
+    roughness: 1.0
+
+  # Etched slab — darkest purple (matches #4c209e)
+  SLAB_NEGATIVE:
+    color: [0.30, 0.13, 0.62, 1.0]
+    metallic: 0.0
+    roughness: 1.0
+
+  # Labels — steel blue (matches #5179b5)
+  LABELS:
+    color: [0.32, 0.47, 0.71, 1.0]
+    metallic: 0.0
+    roughness: 1.0
+
+  # Chip outline — peach (matches #ffc6b8)
+  CHIP_CONTOUR:
+    color: [1.00, 0.78, 0.72, 1.0]
+    metallic: 0.0
+    roughness: 1.0
+
+  # Exclusion zone — vivid mint (matches #00fe9c)
+  CHIP_EXCLUSION_ZONE:
+    color: [0.00, 1.00, 0.61, 1.0]
+    metallic: 0.0
+    roughness: 1.0
+
+  # Electrodes — light blue (matches #8dc2f7)
+  TL:
+    color: [0.55, 0.76, 0.97, 1.0]
+    metallic: 0.0
+    roughness: 1.0
+
+  # Heaters — same hue, different feel (KLayout uses dotted hatch on this layer)
+  HT:
+    color: [0.55, 0.76, 0.97, 1.0]
+    metallic: 0.0
+    roughness: 1.0

--- a/import_gdsii/configs/colors/lnoi400/marketing-gold.yaml
+++ b/import_gdsii/configs/colors/lnoi400/marketing-gold.yaml
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: 2026 Tom <tom@flexcompute.com>
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+name: Marketing (Gold)
+description: Marketing color scheme with gold
+layers:
+  # LN ridge — warm violet with gold overtone
+  LN_RIDGE:
+    color: [0.65, 0.55, 0.78, 1.0]
+    metallic: 0.3
+    roughness: 0.30
+
+  # LN slab — deeper companion shade
+  LN_SLAB:
+    color: [0.52, 0.44, 0.66, 0.90]
+    metallic: 0.3
+    roughness: 0.35
+
+  # Etched slab — deep cool void for contrast
+  SLAB_NEGATIVE:
+    color: [0.08, 0.08, 0.12, 0.55]
+    roughness: 0.55
+
+  # Labels — warm muted brown
+  LABELS:
+    color: [0.40, 0.32, 0.22, 1.0]
+    roughness: 0.55
+
+  # Chip outline — warm gold tint
+  CHIP_CONTOUR:
+    color: [0.96, 0.78, 0.45, 0.7]
+    roughness: 0.6
+
+  # Exclusion zone — soft amber
+  CHIP_EXCLUSION_ZONE:
+    color: [0.92, 0.72, 0.32, 0.35]
+    roughness: 0.6
+
+  # Electrodes — luxurious gold
+  TL:
+    color: [0.98, 0.82, 0.32, 1.0]
+    metallic: 0.90
+    roughness: 0.25
+
+  # Heaters — darker antique gold
+  HT:
+    color: [0.72, 0.55, 0.20, 1.0]
+    metallic: 0.8
+    roughness: 0.35

--- a/import_gdsii/configs/colors/lnoi400/marketing.yaml
+++ b/import_gdsii/configs/colors/lnoi400/marketing.yaml
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: 2026 Tom <tom@flexcompute.com>
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+name: Marketing
+description: Marketing color scheme
+layers:
+  # LN ridge — refined violet
+  LN_RIDGE:
+    color: [0.62, 0.52, 0.78, 1.0]
+    metallic: 0.3
+    roughness: 0.30
+
+  # LN slab — deeper companion shade
+  LN_SLAB:
+    color: [0.50, 0.42, 0.68, 0.90]
+    metallic: 0.3
+    roughness: 0.35
+
+  # Etched slab — dark cool void
+  SLAB_NEGATIVE:
+    color: [0.10, 0.10, 0.16, 0.50]
+    roughness: 0.55
+
+  # Labels — soft slate
+  LABELS:
+    color: [0.30, 0.34, 0.42, 1.0]
+    roughness: 0.55
+
+  # Chip outline — muted peach
+  CHIP_CONTOUR:
+    color: [0.95, 0.74, 0.68, 0.7]
+    roughness: 0.65
+
+  # Exclusion zone — soft teal
+  CHIP_EXCLUSION_ZONE:
+    color: [0.20, 0.78, 0.62, 0.35]
+    roughness: 0.6
+
+  # Electrodes — clean platinum
+  TL:
+    color: [0.86, 0.88, 0.92, 1.0]
+    metallic: 0.85
+    roughness: 0.25
+
+  # Heaters — warm rose-gold accent
+  HT:
+    color: [0.78, 0.55, 0.45, 1.0]
+    metallic: 0.7
+    roughness: 0.40

--- a/import_gdsii/configs/colors/lnoi400/realistic.yaml
+++ b/import_gdsii/configs/colors/lnoi400/realistic.yaml
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: 2026 Tom <tom@flexcompute.com>
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+name: Realistic
+description: Realistic color scheme
+layers:
+  # Lithium niobate ridge — slightly translucent, faint blue-grey crystalline tint
+  LN_RIDGE:
+    color: [0.82, 0.84, 0.92, 0.85]
+    metallic: 0.2
+    roughness: 0.25
+
+  # LN slab beneath the ridge
+  LN_SLAB:
+    color: [0.80, 0.82, 0.90, 0.75]
+    metallic: 0.2
+    roughness: 0.30
+
+  # Etched-away slab regions — rendered as a dark translucent void
+  SLAB_NEGATIVE:
+    color: [0.08, 0.08, 0.10, 0.30]
+    roughness: 0.55
+
+  # Text labels — dark, matte
+  LABELS:
+    color: [0.08, 0.08, 0.08, 1.0]
+    roughness: 0.6
+
+  # Chip outline — soft peach (matches KLayout default)
+  CHIP_CONTOUR:
+    color: [1.00, 0.78, 0.72, 0.6]
+    roughness: 0.7
+
+  # Exclusion zone — subtle warning green
+  CHIP_EXCLUSION_ZONE:
+    color: [0.00, 1.00, 0.61, 0.30]
+    roughness: 0.7
+
+  # RF / EO drive electrodes — gold (typical for LNOI EO modulators)
+  TL:
+    color: [0.92, 0.78, 0.45, 1.0]
+    metallic: 0.95
+    roughness: 0.25
+
+  # Heater traces — darker resistive metal (NiCr-like)
+  HT:
+    color: [0.55, 0.50, 0.45, 1.0]
+    metallic: 0.7
+    roughness: 0.45

--- a/import_gdsii/configs/lnoi400.yaml
+++ b/import_gdsii/configs/lnoi400.yaml
@@ -1,0 +1,68 @@
+# SPDX-FileCopyrightText: 2026 Tom <tom@flexcompute.com>
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# Luxtelligence LNOI400 PDK — thin-film lithium niobate on insulator (X-cut LNOI)
+# Reference: https://github.com/Luxtelligence/lxt_pdk_gf  (lnoi400/tech.py, lnoi400/layers.yaml)
+#
+# Implicit (not GDS) layers in the stack:
+#   - 525 µm Si handle wafer (substrate, zmin = -14.7 µm)
+#   - 4.7 µm buried oxide (SiO2)
+#   - 2 µm SiO2 upper cladding above the LN device layer
+# Only patterned layers have GDS index/type pairs and are extruded below.
+
+# Patterned LN ridge waveguide (200 nm ridge on top of slab)
+LN_RIDGE:
+  index: 2
+  type: 0
+  z: 0.200
+  height: 0.200
+
+# 200 nm LN slab beneath the ridge
+LN_SLAB:
+  index: 3
+  type: 0
+  z: 0.0
+  height: 0.200
+
+# Negative tone of slab — region where the slab has been etched away
+SLAB_NEGATIVE:
+  index: 3
+  type: 1
+  z: 0.0
+  height: 0.200
+
+# Text labels — thin sliver above metal so they do not occlude geometry
+LABELS:
+  index: 4
+  type: 0
+  z: 2.310
+  height: 0.010
+
+# Chip outline — thin marker at substrate level
+CHIP_CONTOUR:
+  index: 6
+  type: 0
+  z: -0.010
+  height: 0.010
+
+# Chip exclusion zone (no-go region for components)
+CHIP_EXCLUSION_ZONE:
+  index: 6
+  type: 1
+  z: -0.010
+  height: 0.010
+
+# Transmission-line electrode metal (RF/EO drive electrodes)
+TL:
+  index: 21
+  type: 0
+  z: 1.400
+  height: 0.900
+
+# Heater traces (resistive thin-film heaters for thermo-optic phase shifters)
+HT:
+  index: 21
+  type: 1
+  z: 1.400
+  height: 0.900


### PR DESCRIPTION
## Summary

- New PDK: Luxtelligence LNOI400 (thin-film lithium niobate photonics, X-cut LNOI with 200 nm slab + 200 nm ridge), source: https://github.com/Luxtelligence/lxt_pdk_gf.
- 8-layer stack in `configs/lnoi400.yaml` — LN_RIDGE, LN_SLAB, SLAB_NEGATIVE, LABELS, CHIP_CONTOUR, CHIP_EXCLUSION_ZONE, TL, HT — derived from upstream `lnoi400/tech.py` (z + thickness) and `lnoi400/layers.yaml` (GDS index/datatype).
- Four matching color schemes under `configs/colors/lnoi400/`: realistic / fancy / marketing / marketing-gold.
- Registered in `PDK_CONFIGS` and the pre-import dialog enum in `import_gdsii/__init__.py`; README "Supported PDKs" list updated.

Implicit substrate (525 µm Si), 4.7 µm buried oxide, and 2 µm SiO₂ cladding don't have GDS shapes upstream, so they're omitted from the extruded stack.
