### PR TITLE
import_gdsii: v1.0.3

### DIFF
--- a/import_gdsii/blender_manifest.toml
+++ b/import_gdsii/blender_manifest.toml
@@ -5,7 +5,7 @@
 schema_version = "1.0.0"
 
 id = "import_gdsii"
-version = "1.0.2"
+version = "1.0.3"
 name = "GDSII Importer"
 tagline = "GDSII importer with PDK layer stack support"
 maintainer = "aesc silicon"


### PR DESCRIPTION
Add SiEPIC EBeam and Luxtelligence LNOI400 PDK configs.

Fix ChipBase size (now 20 mm) to prevent visible edges in renders. Fix chip base and camera placement for layouts whose bounding box doesn't start at GDS origin.

Fix custom configuration import missing color file after YAML split. Improve user feedback on missing files.

Fix build script reading version from git tag history and prevent duplicate -dirty suffix in ZIP filenames.

Update README to reflect separate color scheme config files.