### PR TITLE
Auto-discover PDKs from configs directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 venv/
 import_gdsii/wheels/
 *.zip
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -166,6 +166,50 @@ Each layer entry supports:
 
 Layers not listed in the schema are rendered with a default grey material.
 
+## Adding a New PDK
+
+PDKs are **auto-discovered** from the `import_gdsii/configs/` directory — there
+is no hard-coded list in the Python source to keep in sync. Adding a PDK is a
+matter of dropping in YAML files; **no code changes are required**.
+
+To add a PDK with stem `<pdk>` (e.g. `mypdk`):
+
+1. **Layer stack** — create `import_gdsii/configs/<pdk>.yaml` describing each
+   layer (`index`, `type`, `z`, `height`), using the format shown under
+   [Layer Configuration](#layer-configuration). The `index`/`type` values must
+   match the GDS layer/datatype numbers used by the PDK; `z`/`height` are the
+   3D stack positions in micrometers (estimates are fine for visualization).
+
+2. **Color scheme** — create at least
+   `import_gdsii/configs/colors/<pdk>/realistic.yaml`. The layer names must
+   match the keys in the layer stack exactly. Add `fancy.yaml`,
+   `marketing.yaml`, `marketing-gold.yaml` for extra schemes if you like.
+
+3. **(Optional) Friendly name** — add an entry to
+   `import_gdsii/configs/pdks.yaml` to give the PDK a display name, description
+   and position in the dropdown:
+
+   ```yaml
+   mypdk:
+     name: My Fancy PDK
+     description: 65nm example process
+   ```
+
+   Without an entry, the PDK still appears, using its filename as the label.
+
+The new PDK shows up in the **Select PDK** dropdown automatically the next time
+the importer is launched. The enum key is the upper-cased stem (`mypdk` →
+`MYPDK`, `ihp-sg13g2` → `IHP_SG13G2`).
+
+You can validate your YAML files before building with:
+
+```bash
+python scripts/internal/check_configs.py
+```
+
+This checks the layer-stack schema and verifies that every color scheme covers
+exactly the layers defined in the stack.
+
 ## Contributing
 
 Contributions are welcome! Please feel free to submit pull requests or open issues on the [GitHub repository](https://github.com/aesc-silicon/BlenderGDS).

--- a/import_gdsii/__init__.py
+++ b/import_gdsii/__init__.py
@@ -28,40 +28,109 @@ import yaml
 # ============================================================================
 # PDK DEFINITIONS
 # ============================================================================
+#
+# PDKs are *auto-discovered* from the ``configs/`` directory — there is no
+# hard-coded list to keep in sync.  To add a new PDK, simply drop in:
+#
+#   * configs/<pdk>.yaml                  -> the layer stack (index/type/z/height)
+#   * configs/colors/<pdk>/realistic.yaml -> at least one color scheme
+#
+# and (optionally) add a friendly name/description/ordering to
+# ``configs/pdks.yaml``.  No Python changes are required.  See the
+# "Adding a PDK" section of the README for details.
 
-# PDK Configuration paths
-PDK_CONFIGS = {
-    'IHP_SG13G2': {
-        'name': 'IHP Open PDK (SG13G2)',
-        'config_path': 'configs/ihp-sg13g2.yaml',
-        'color_path': 'configs/colors/ihp-sg13g2/'
-    },
-    'IHP_SG13CMOS5L': {
-        'name': 'IHP Open PDK (SG13CMOS5L)',
-        'config_path': 'configs/ihp-sg13cmos5l.yaml',
-        'color_path': 'configs/colors/ihp-sg13cmos5l/'
-    },
-    'SKY130': {
-        'name': 'SkyWater SKY130 PDK',
-        'config_path': 'configs/sky130.yaml',
-        'color_path': 'configs/colors/sky130/'
-    },
-    'GF180MCU': {
-        'name': 'GlobalFoundries GF180MCU PDK',
-        'config_path': 'configs/gf180mcu.yaml',
-        'color_path': 'configs/colors/gf180mcu/'
-    },
-    'SIEPIC_EBEAM': {
-        'name': 'SiEPIC EBeam PDK',
-        'config_path': 'configs/siepic.yaml',
-        'color_path': 'configs/colors/siepic/'
-    },
-    'LNOI400': {
-        'name': 'Luxtelligence LNOI400 PDK',
-        'config_path': 'configs/lnoi400.yaml',
-        'color_path': 'configs/colors/lnoi400/'
-    },
-}
+# Filename of the optional PDK metadata file inside configs/.
+PDK_META_FILE = 'pdks.yaml'
+
+# Preferred default PDK key (used when present among the discovered PDKs).
+PREFERRED_DEFAULT_PDK = 'IHP_SG13G2'
+
+
+def _pdk_key_from_stem(stem):
+    """Derive a stable enum key from a config filename stem.
+
+    e.g. ``ihp-sg13g2`` -> ``IHP_SG13G2``, ``sky130`` -> ``SKY130``.
+    """
+    return stem.upper().replace('-', '_')
+
+
+def discover_pdks():
+    """Scan ``configs/`` and return an ordered dict of PDK definitions.
+
+    Each value is a dict with ``name``, ``description``, ``config_path``,
+    ``color_path`` and ``stem``.  Friendly names, descriptions and display
+    order can optionally be supplied by ``configs/pdks.yaml``; anything not
+    listed there is still discovered and gets a sensible default name.
+    """
+    addon_dir = Path(__file__).parent
+    configs_dir = addon_dir / 'configs'
+
+    # Optional metadata: { <stem>: {name, description}, ... } plus optional
+    # top-level "order" list of stems controlling display order.
+    meta = {}
+    order = []
+    meta_file = configs_dir / PDK_META_FILE
+    if meta_file.is_file():
+        try:
+            loaded = yaml.safe_load(meta_file.read_text(encoding='utf-8')) or {}
+            order = loaded.pop('order', []) or []
+            meta = loaded
+        except Exception as exc:  # pragma: no cover - defensive
+            print(f"⚠ Could not parse {PDK_META_FILE}: {exc}")
+
+    # Discover available layer-stack configs (everything except the metadata file).
+    found = {}
+    if configs_dir.is_dir():
+        for cfg in sorted(configs_dir.glob('*.yaml')):
+            if cfg.name == PDK_META_FILE:
+                continue
+            found[cfg.stem] = cfg.name
+
+    # Order: explicit "order" first, then any meta-listed stems, then the rest
+    # alphabetically — so curated PDKs appear first and new drop-ins still show.
+    ordered_stems = [s for s in order if s in found]
+    ordered_stems += [s for s in meta if s in found and s not in ordered_stems]
+    ordered_stems += [s for s in found if s not in ordered_stems]
+
+    pdks = {}
+    for stem in ordered_stems:
+        entry = meta.get(stem) or {}
+        key = _pdk_key_from_stem(stem)
+        pdks[key] = {
+            'name': entry.get('name', stem),
+            'description': entry.get('description', f"{stem} PDK"),
+            'config_path': f"configs/{found[stem]}",
+            'color_path': f"configs/colors/{stem}/",
+            'stem': stem,
+        }
+    return pdks
+
+
+# Discovered at import time. Re-discovery happens on register() so newly
+# dropped-in configs are picked up without restarting Blender.
+PDK_CONFIGS = discover_pdks()
+
+
+def get_default_pdk():
+    """Return the default PDK key — the preferred one if available, else first."""
+    if PREFERRED_DEFAULT_PDK in PDK_CONFIGS:
+        return PREFERRED_DEFAULT_PDK
+    return next(iter(PDK_CONFIGS), PREFERRED_DEFAULT_PDK)
+
+
+# Cache for the dynamically-built PDK enum items. Blender requires that the
+# strings backing EnumProperty items stay alive, so we keep them module-level.
+_PDK_ENUM_ITEMS = []
+
+
+def get_pdk_items(self, context):
+    """Build EnumProperty items from the discovered PDKs (Blender callback)."""
+    _PDK_ENUM_ITEMS.clear()
+    for key, info in PDK_CONFIGS.items():
+        _PDK_ENUM_ITEMS.append((key, info['name'], info.get('description', info['name'])))
+    if not _PDK_ENUM_ITEMS:
+        _PDK_ENUM_ITEMS.append(('NONE', 'No PDK configs found', 'No layer-stack configs in configs/'))
+    return _PDK_ENUM_ITEMS
 
 
 # ============================================================================
@@ -322,7 +391,7 @@ def get_color_schemes(self, context):
     """Dynamically generate color scheme list based on selected PDK"""
     items = []
 
-    pdk = getattr(context.scene, 'gdsii_pdk_selection', 'IHP_SG13G2')
+    pdk = getattr(context.scene, 'gdsii_pdk_selection', get_default_pdk())
     addon_dir = Path(__file__).parent
     color_path = addon_dir / PDK_CONFIGS.get(pdk, {}).get('color_path', pdk)
     schemes = [('realistic', 'Realistic', 'Realistic color scheme')]
@@ -345,15 +414,7 @@ class GDSIIPreImportDialog(bpy.types.Operator):
     pdk_selection: EnumProperty(
         name="PDK",
         description="Process Design Kit to use for layer stack",
-        items=[
-            ('IHP_SG13G2', "IHP Open PDK SG13G2", "IHP SG13G2 130nm BiCMOS process"),
-            ('IHP_SG13CMOS5L', "IHP Open PDK SG13CMOS5L", "IHP SG13CMOS5L 130nm CMOS5L process"),
-            ('SKY130', "SkyWater SKY130 PDK", "SkyWater SKY130 130nm process"),
-            ('GF180MCU', "GlobalFoundries GF180MCU PDK", "GlobalFoundries GF180MCU 180nm process"),
-            ('SIEPIC_EBEAM', "SiEPIC EBeam PDK", "SiEPIC EBeam silicon photonics PDK (220 nm SOI)"),
-            ('LNOI400', "Luxtelligence LNOI400 PDK", "Luxtelligence LNOI400 thin-film lithium niobate (X-cut, 400 nm LN, 200 nm etch) photonics PDK"),
-        ],
-        default='IHP_SG13G2',
+        items=get_pdk_items,
     )
 
     use_custom_config: BoolProperty(
@@ -377,6 +438,12 @@ class GDSIIPreImportDialog(bpy.types.Operator):
     )
 
     def invoke(self, context, event):
+        # Default to the preferred PDK if it is available among the discovered set.
+        try:
+            self.pdk_selection = get_default_pdk()
+        except TypeError:
+            # Value not in the (dynamic) enum item set — leave Blender's default.
+            pass
         # Set default config path based on PDK selection
         self.update_config_path()
         return context.window_manager.invoke_props_dialog(self, width=400)
@@ -576,7 +643,7 @@ class ImportGDSII(bpy.types.Operator, ImportHelper):
         box = layout.box()
         box.label(text="Selected PDK:", icon='PRESET')
         if not use_custom:
-            pdk = getattr(context.scene, 'gdsii_pdk_selection', 'IHP_SG13G2')
+            pdk = getattr(context.scene, 'gdsii_pdk_selection', get_default_pdk())
             pdk_name = PDK_CONFIGS.get(pdk, {}).get('name', pdk)
         else:
             pdk_name = "Custom"
@@ -589,7 +656,7 @@ class ImportGDSII(bpy.types.Operator, ImportHelper):
         """Main import function"""
         try:
             # Get PDK settings from scene
-            pdk_selection = getattr(context.scene, 'gdsii_pdk_selection', 'IHP_SG13G2')
+            pdk_selection = getattr(context.scene, 'gdsii_pdk_selection', get_default_pdk())
             use_custom = getattr(context.scene, 'gdsii_use_custom_config', False)
             custom_config_path = getattr(context.scene, 'gdsii_custom_config_path', '')
             custom_color_path = getattr(context.scene, 'gdsii_custom_color_path', '')
@@ -726,7 +793,7 @@ def menu_func_import(self, context):
 
 # Properties to store PDK settings in scene
 def register_properties():
-    bpy.types.Scene.gdsii_pdk_selection = StringProperty(default='IHP_SG13G2')
+    bpy.types.Scene.gdsii_pdk_selection = StringProperty(default=get_default_pdk())
     bpy.types.Scene.gdsii_use_custom_config = BoolProperty(default=False)
     bpy.types.Scene.gdsii_custom_config_path = StringProperty(default='')
     bpy.types.Scene.gdsii_custom_color_path = StringProperty(default='')
@@ -743,6 +810,11 @@ classes = (
 )
 
 def register():
+    # Re-discover PDKs so configs dropped in since the module was first
+    # imported are picked up without restarting Blender.
+    global PDK_CONFIGS
+    PDK_CONFIGS = discover_pdks()
+
     register_properties()
 
     for cls in classes:

--- a/import_gdsii/configs/pdks.yaml
+++ b/import_gdsii/configs/pdks.yaml
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: 2026 aesc silicon
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Optional PDK metadata for the GDSII importer.
+#
+# PDKs are auto-discovered from this directory: every "<stem>.yaml" layer-stack
+# file (except this one) becomes a selectable PDK whose enum key is the upper-
+# cased stem (e.g. "sky130" -> "SKY130", "ihp-sg13g2" -> "IHP_SG13G2").
+#
+# This file is purely cosmetic — it lets you give each PDK a friendly display
+# name, a description and a display order. Any config not listed here is still
+# discovered and shown using its filename as the name. To add a PDK you do NOT
+# need to edit any Python: drop a "configs/<stem>.yaml" layer stack and a
+# "configs/colors/<stem>/realistic.yaml" color scheme, then (optionally) add an
+# entry below.
+
+# Display order in the PDK dropdown. Stems not listed fall back to alphabetical.
+order:
+  - ihp-sg13g2
+  - ihp-sg13cmos5l
+  - sky130
+  - gf180mcu
+  - freepdk45
+  - asap7
+  - siepic
+  - lnoi400
+
+ihp-sg13g2:
+  name: IHP Open PDK (SG13G2)
+  description: IHP SG13G2 130nm BiCMOS process
+
+ihp-sg13cmos5l:
+  name: IHP Open PDK (SG13CMOS5L)
+  description: IHP SG13CMOS5L 130nm CMOS5L process
+
+sky130:
+  name: SkyWater SKY130 PDK
+  description: SkyWater SKY130 130nm process
+
+gf180mcu:
+  name: GlobalFoundries GF180MCU PDK
+  description: GlobalFoundries GF180MCU 180nm process
+
+freepdk45:
+  name: FreePDK45 / Nangate45 PDK
+  description: FreePDK45 45nm open predictive PDK (10 metal layers)
+
+asap7:
+  name: ASAP7 PDK
+  description: ASAP7 ASU 7nm FinFET predictive PDK (4x-scaled GDS)
+
+siepic:
+  name: SiEPIC EBeam PDK
+  description: SiEPIC EBeam silicon photonics PDK (220 nm SOI)
+
+lnoi400:
+  name: Luxtelligence LNOI400 PDK
+  description: >-
+    Luxtelligence LNOI400 thin-film lithium niobate
+    (X-cut, 400 nm LN, 200 nm etch) photonics PDK

--- a/scripts/internal/check_configs.py
+++ b/scripts/internal/check_configs.py
@@ -14,7 +14,13 @@ with open(script_dir / 'color-schema.schema.json', encoding='utf-8') as f:
 
 project_dir = script_dir.parent.parent
 pdks = project_dir / "import_gdsii/configs"
+
+# Not a layer stack — purely optional PDK display metadata (names/order).
+META_FILE = "pdks.yaml"
+
 for process in pdks.glob('*yaml'):
+    if process.name == META_FILE:
+        continue
     print(f"Found process: {process.stem}")
 
     pdk_file = yaml.safe_load(process.read_text(encoding='utf-8'))


### PR DESCRIPTION
Replace the hard-coded PDK_CONFIGS dict and the duplicated EnumProperty item list with a single auto-discovery mechanism that scans configs/ for layer-stack YAMLs. Each <stem>.yaml becomes a selectable PDK; friendly names, descriptions and ordering come from an optional configs/pdks.yaml metadata file. Adding a PDK now requires only dropping in YAML files, with no Python changes.

- Add discover_pdks(), get_default_pdk() and a dynamic get_pdk_items() enum callback; re-discover on register().
- Add configs/pdks.yaml with display metadata for the existing PDKs.
- Skip pdks.yaml in check_configs.py so it is not validated as a stack.
- Document the drop-in workflow in the README.
- Ignore __pycache__/*.pyc.


Claude-Session: https://claude.ai/code/session_01C2oxmLfdQkipGJ2zh1G4Sp