### PR TITLE
Add dynamic preset support

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,21 @@ Each layer requires:
 * `z`: Z-position in micrometers
 * `height`: Layer thickness in micrometers
 
+An optional field with metadata can be added to customize Blender's behavior when reading the file:
+
+```yaml
+pdk_config:
+  name: SkyWater SKY130 PDK
+  description: SkyWater SKY130 130nm process
+  order: 3
+  def_color: realistic
+```
+
+All metadata is optional:
+* `name/description` - Extra details of PDK. Takes file name if unset
+* `order` - Sets order of PDKs as they will appear in Blender's dropdown. Defaults to "0"
+* `def_color` - Sets default color scheme to be used for the PDK. Defaults to alphabetic order
+
 #### Parameters
 
 - `pdk` - Process Design Kit specification (e.g., `ihp-sg13g2`)

--- a/README.md
+++ b/README.md
@@ -139,7 +139,6 @@ An optional field with metadata can be added to customize Blender's behavior whe
 pdk_config:
   name: SkyWater SKY130 PDK
   description: SkyWater SKY130 130nm process
-  order: 3
   def_color: realistic
 ```
 

--- a/import_gdsii/__init__.py
+++ b/import_gdsii/__init__.py
@@ -30,6 +30,30 @@ import yaml
 # ============================================================================
 
 # PDK Configuration paths
+def load_pdf_configs(configs_dir="configs"):
+    pdks = {}
+
+    yaml_files = [
+        f for f in os.listdir(configs_dir)
+        if f.endswith('.yaml') and os.path.isfile(os.path.join(configs_dir, f))
+    ]
+
+    for yaml_file in yaml_files:
+        file_name = yaml_file[:-5]
+        key = file_name.upper().replace('-', '_')
+
+        config_path = os.path.join(configs_dir, yaml_file)
+        with open(config_path) as f:
+            config = yaml.safe_load(f)["pdk_config"]
+
+        pdks[key] = {
+            'config_path': config_path,
+            'color_path': os.path.join(configs_dir, 'colors', file_name, ''),
+            **config,  # name, order, default, and whatever else is in the YAML
+        }
+
+    return pdks
+
 PDK_CONFIGS = {
     'IHP_SG13G2': {
         'name': 'IHP Open PDK (SG13G2)',

--- a/import_gdsii/__init__.py
+++ b/import_gdsii/__init__.py
@@ -30,62 +30,46 @@ import yaml
 # ============================================================================
 
 # PDK Configuration paths
-def load_pdf_configs(configs_dir="configs"):
+def load_pdk_configs(configs_dir=Path(__file__).parent / "configs"):
     pdks = {}
-
     yaml_files = [
         f for f in os.listdir(configs_dir)
-        if f.endswith('.yaml') and os.path.isfile(os.path.join(configs_dir, f))
+        if f.endswith('.yaml') and os.path.isfile(configs_dir / f)
     ]
 
     for yaml_file in yaml_files:
         file_name = yaml_file[:-5]
         key = file_name.upper().replace('-', '_')
 
-        config_path = os.path.join(configs_dir, yaml_file)
+        config_path = configs_dir / yaml_file
         with open(config_path) as f:
-            config = yaml.safe_load(f)["pdk_config"]
+            config = yaml.safe_load(f)
 
         pdks[key] = {
-            'config_path': config_path,
-            'color_path': os.path.join(configs_dir, 'colors', file_name, ''),
-            **config,  # name, order, default, and whatever else is in the YAML
+            'config_path': config_path, # Don't acces per-layer info yet
+            'color_path': configs_dir / 'colors' / file_name,
+            'file_name': file_name,
         }
+        if "pdk_config" in config:
+            # name, description, order, def_color
+            pdks[key].update(**config["pdk_config"])
+        # Fill in defaults if not set
+        if "name" not in pdks[key]:
+            pdks[key]["name"] = key
+        if "description" not in pdks[key]:
+            pdks[key]["description"] = key
+        if "order" not in pdks[key]:
+            pdks[key]["order"] = 0
+        if "def_color" not in pdks[key]:
+            pdks[key]["def_color"] = "realistic" # Should be None
 
-    return pdks
+    # Return sorted "pdks" dictionary by "order" and then alphabetically
+    return dict(sorted(
+        pdks.items(),
+        key=lambda kv: (kv[1]["order"], kv[0])
+    ))
 
-PDK_CONFIGS = {
-    'IHP_SG13G2': {
-        'name': 'IHP Open PDK (SG13G2)',
-        'config_path': 'configs/ihp-sg13g2.yaml',
-        'color_path': 'configs/colors/ihp-sg13g2/'
-    },
-    'IHP_SG13CMOS5L': {
-        'name': 'IHP Open PDK (SG13CMOS5L)',
-        'config_path': 'configs/ihp-sg13cmos5l.yaml',
-        'color_path': 'configs/colors/ihp-sg13cmos5l/'
-    },
-    'SKY130': {
-        'name': 'SkyWater SKY130 PDK',
-        'config_path': 'configs/sky130.yaml',
-        'color_path': 'configs/colors/sky130/'
-    },
-    'GF180MCU': {
-        'name': 'GlobalFoundries GF180MCU PDK',
-        'config_path': 'configs/gf180mcu.yaml',
-        'color_path': 'configs/colors/gf180mcu/'
-    },
-    'SIEPIC_EBEAM': {
-        'name': 'SiEPIC EBeam PDK',
-        'config_path': 'configs/siepic.yaml',
-        'color_path': 'configs/colors/siepic/'
-    },
-    'LNOI400': {
-        'name': 'Luxtelligence LNOI400 PDK',
-        'config_path': 'configs/lnoi400.yaml',
-        'color_path': 'configs/colors/lnoi400/'
-    },
-}
+PDK_CONFIGS = load_pdk_configs()
 
 
 # ============================================================================
@@ -239,7 +223,10 @@ def _create_merged_gds(gds_path, layerstack, tmp_dir):
     merged_layout.dbu = layout.dbu
     merged_top_cell = merged_layout.create_cell(top_cell.name)
 
-    for data in layerstack.values():
+    print("layerstack",layerstack)
+    for layer_name, data in layerstack.items():
+        if layer_name=="pdk_config":
+            continue
         layer = (data['index'], data['type'])
         layer_index = layout.layer(*layer)
         region = db.Region(top_cell.begin_shapes_rec(layer_index))
@@ -342,21 +329,33 @@ def create_extruded_layer(report, gds_path, z, height, layer, name, color, unit=
 # PRE-IMPORT PDK SELECTION DIALOG
 # ============================================================================
 
+def get_pdk_list(self, context):
+    """Dynamically generate pdk list"""
+    
+    pdk_list = []
+    for k,v in PDK_CONFIGS.items():
+        pdk_list.append(
+            (k, v["name"], v["description"])
+        )
+    return pdk_list
+
 def get_color_schemes(self, context):
     """Dynamically generate color scheme list based on selected PDK"""
-    items = []
 
     pdk = getattr(context.scene, 'gdsii_pdk_selection', 'IHP_SG13G2')
     addon_dir = Path(__file__).parent
-    color_path = addon_dir / PDK_CONFIGS.get(pdk, {}).get('color_path', pdk)
-    schemes = [('realistic', 'Realistic', 'Realistic color scheme')]
+    pdf_dict = PDK_CONFIGS.get(pdk, {})
+    color_path = addon_dir / pdf_dict.get('color_path', pdk)
+    schemes = []
     for file in color_path.glob('*yaml'):
-        # Make sure realistic is the default choice
-        if file.stem == 'realistic':
-            continue
         color_file = yaml.safe_load(file.read_text(encoding='utf-8'))
-        schemes.append((file.stem, color_file.get('name', file.stem),
-                       color_file.get('description', file.stem)))
+        if file.stem==pdf_dict["def_color"]:
+
+            schemes.insert(0,(file.stem, color_file.get('name', file.stem),
+                        color_file.get('description', file.stem)))
+        else:
+            schemes.append((file.stem, color_file.get('name', file.stem),
+                        color_file.get('description', file.stem)))
     return schemes
 
 
@@ -369,15 +368,7 @@ class GDSIIPreImportDialog(bpy.types.Operator):
     pdk_selection: EnumProperty(
         name="PDK",
         description="Process Design Kit to use for layer stack",
-        items=[
-            ('IHP_SG13G2', "IHP Open PDK SG13G2", "IHP SG13G2 130nm BiCMOS process"),
-            ('IHP_SG13CMOS5L', "IHP Open PDK SG13CMOS5L", "IHP SG13CMOS5L 130nm CMOS5L process"),
-            ('SKY130', "SkyWater SKY130 PDK", "SkyWater SKY130 130nm process"),
-            ('GF180MCU', "GlobalFoundries GF180MCU PDK", "GlobalFoundries GF180MCU 180nm process"),
-            ('SIEPIC_EBEAM', "SiEPIC EBeam PDK", "SiEPIC EBeam silicon photonics PDK (220 nm SOI)"),
-            ('LNOI400', "Luxtelligence LNOI400 PDK", "Luxtelligence LNOI400 thin-film lithium niobate (X-cut, 400 nm LN, 200 nm etch) photonics PDK"),
-        ],
-        default='IHP_SG13G2',
+        items=get_pdk_list,
     )
 
     use_custom_config: BoolProperty(
@@ -414,10 +405,12 @@ class GDSIIPreImportDialog(bpy.types.Operator):
             config_file = addon_dir / pdk_info['config_path']
             if config_file.exists():
                 self.custom_config_path = str(config_file)
-            default_color = addon_dir / pdk_info['color_path'] / 'realistic.yaml'
+            if pdk_info["def_color"] is None:
+                return
+            default_color = addon_dir / pdk_info['color_path'] / f"{pdk_info['def_color']}.yaml"
             if default_color.exists():
                 self.custom_color_path = str(default_color)
-
+    # TODO: don't use os.join and use this syntax instead everywhere
     def draw(self, context):
         layout = self.layout
 
@@ -506,7 +499,7 @@ class ImportGDSII(bpy.types.Operator, ImportHelper):
     color_scheme: EnumProperty(
         name="Color Scheme",
         description="Select color scheme for the PDK",
-        items=get_color_schemes
+        items=get_color_schemes,
     )
 
     # Crop region options
@@ -600,7 +593,7 @@ class ImportGDSII(bpy.types.Operator, ImportHelper):
         box = layout.box()
         box.label(text="Selected PDK:", icon='PRESET')
         if not use_custom:
-            pdk = getattr(context.scene, 'gdsii_pdk_selection', 'IHP_SG13G2')
+            pdk = getattr(context.scene, 'gdsii_pdk_selection', next(iter(PDK_CONFIGS)))
             pdk_name = PDK_CONFIGS.get(pdk, {}).get('name', pdk)
         else:
             pdk_name = "Custom"
@@ -613,7 +606,7 @@ class ImportGDSII(bpy.types.Operator, ImportHelper):
         """Main import function"""
         try:
             # Get PDK settings from scene
-            pdk_selection = getattr(context.scene, 'gdsii_pdk_selection', 'IHP_SG13G2')
+            pdk_selection = getattr(context.scene, 'gdsii_pdk_selection', next(iter(PDK_CONFIGS)))
             use_custom = getattr(context.scene, 'gdsii_use_custom_config', False)
             custom_config_path = getattr(context.scene, 'gdsii_custom_config_path', '')
             custom_color_path = getattr(context.scene, 'gdsii_custom_color_path', '')
@@ -625,7 +618,8 @@ class ImportGDSII(bpy.types.Operator, ImportHelper):
                 # Use built-in PDK config
                 pdk_info = PDK_CONFIGS.get(pdk_selection, {})
                 addon_dir = Path(__file__).parent
-                yamlfile = addon_dir / pdk_info.get('config_path', 'configs/ihp-sg13g2.yaml')
+                yamlfile = addon_dir / pdk_info.get('config_path', 'configs/'+
+                pdk_info["file_name"]+'.yaml')
 
             # Load layer stack configuration
             if not yamlfile.is_file():
@@ -675,7 +669,7 @@ class ImportGDSII(bpy.types.Operator, ImportHelper):
             if use_custom:
                 colorfile = Path(custom_color_path)
             else:
-                color_dir = addon_dir / pdk_info.get('color_path', 'configs/colors/ihp-sg13g2')
+                color_dir = addon_dir / pdk_info.get('color_path', 'configs/colors/'+pdk_info["file_name"])
                 colorfile = color_dir / f"{self.color_scheme}.yaml"
             if not colorfile.is_file():
                 self.report({'ERROR'}, f"Color schema file not found: {colorfile}")
@@ -697,6 +691,8 @@ class ImportGDSII(bpy.types.Operator, ImportHelper):
             # Import each layer from the stack
             imported_count = 0
             for layer_name, data in layerstack.items():
+                if layer_name=="pdk_config":
+                    continue
                 z = data['z'] * self.z_scale
                 height = data['height'] * self.z_scale
                 layer_index = (data['index'], data['type'])
@@ -750,7 +746,7 @@ def menu_func_import(self, context):
 
 # Properties to store PDK settings in scene
 def register_properties():
-    bpy.types.Scene.gdsii_pdk_selection = StringProperty(default='IHP_SG13G2')
+    bpy.types.Scene.gdsii_pdk_selection = StringProperty(default=next(iter(PDK_CONFIGS)))
     bpy.types.Scene.gdsii_use_custom_config = BoolProperty(default=False)
     bpy.types.Scene.gdsii_custom_config_path = StringProperty(default='')
     bpy.types.Scene.gdsii_custom_color_path = StringProperty(default='')

--- a/import_gdsii/__init__.py
+++ b/import_gdsii/__init__.py
@@ -61,7 +61,7 @@ def load_pdk_configs(configs_dir=Path(__file__).parent / "configs"):
         if "order" not in pdks[key]:
             pdks[key]["order"] = 0
         if "def_color" not in pdks[key]:
-            pdks[key]["def_color"] = "realistic" # Should be None
+            pdks[key]["def_color"] = ""
 
     # Return sorted "pdks" dictionary by "order" and then alphabetically
     return dict(sorted(
@@ -423,7 +423,7 @@ class GDSIIPreImportDialog(bpy.types.Operator):
             config_file = addon_dir / pdk_info['config_path']
             if config_file.exists():
                 self.custom_config_path = str(config_file)
-            if pdk_info["def_color"] is None:
+            if pdk_info["def_color"] == "":
                 return
             default_color = addon_dir / pdk_info['color_path'] / f"{pdk_info['def_color']}.yaml"
             if default_color.exists():

--- a/import_gdsii/__init__.py
+++ b/import_gdsii/__init__.py
@@ -629,8 +629,7 @@ class ImportGDSII(bpy.types.Operator, ImportHelper):
                 # Use built-in PDK config
                 pdk_info = PDK_CONFIGS.get(pdk_selection, {})
                 addon_dir = Path(__file__).parent
-                yamlfile = addon_dir / pdk_info.get('config_path', 'configs/'+
-                pdk_info["file_name"]+'.yaml')
+                yamlfile = addon_dir / pdk_info.get('config_path', f"configs/{pdk_info["file_name"]}.yaml")
 
             # Load layer stack configuration
             if not yamlfile.is_file():
@@ -680,7 +679,7 @@ class ImportGDSII(bpy.types.Operator, ImportHelper):
             if use_custom:
                 colorfile = Path(custom_color_path)
             else:
-                color_dir = addon_dir / pdk_info.get('color_path', 'configs/colors/'+pdk_info["file_name"])
+                color_dir = addon_dir / pdk_info.get('color_path', f"configs/colors/{pdk_info["file_name"]}")
                 colorfile = color_dir / f"{self.color_scheme}.yaml"
             if not colorfile.is_file():
                 self.report({'ERROR'}, f"Color schema file not found: {colorfile}")

--- a/import_gdsii/__init__.py
+++ b/import_gdsii/__init__.py
@@ -32,16 +32,15 @@ import yaml
 # PDK Configuration paths
 def load_pdk_configs(configs_dir=Path(__file__).parent / "configs"):
     pdks = {}
-    yaml_files = [
-        f for f in os.listdir(configs_dir)
-        if f.endswith('.yaml') and os.path.isfile(configs_dir / f)
-    ]
 
-    for yaml_file in yaml_files:
-        file_name = yaml_file[:-5]
-        key = file_name.upper().replace('-', '_')
+    for config_path in configs_dir.iterdir():
+        if not(config_path.is_file() and
+               config_path.suffix.lower() in [".yaml, .yml"]):
+            continue
+        
+        file_name = config_path.stem
+        key = file_name.upper().replace('-', '_') # Expected key format
 
-        config_path = configs_dir / yaml_file
         with open(config_path) as f:
             config = yaml.safe_load(f)
 
@@ -51,17 +50,12 @@ def load_pdk_configs(configs_dir=Path(__file__).parent / "configs"):
             'file_name': file_name,
         }
         if "pdk_config" in config:
-            # name, description, order, def_color
+            # name, description, def_color
             pdks[key].update(**config["pdk_config"])
-        # Fill in defaults if not set
-        if "name" not in pdks[key]:
-            pdks[key]["name"] = key
-        if "description" not in pdks[key]:
-            pdks[key]["description"] = key
-        if "order" not in pdks[key]:
-            pdks[key]["order"] = 0
-        if "def_color" not in pdks[key]:
-            pdks[key]["def_color"] = ""
+        
+        pdks[key].setdefault("name", key)
+        pdks[key].setdefault("description", key)
+        pdks[key].setdefault("def_color", "")
 
     # Return sorted "pdks" dictionary by "order" and then alphabetically
     return dict(sorted(
@@ -240,7 +234,6 @@ def _create_merged_gds(gds_path, layerstack, tmp_dir):
     merged_layout.dbu = layout.dbu
     merged_top_cell = merged_layout.create_cell(top_cell.name)
 
-    print("layerstack",layerstack)
     for layer_name, data in layerstack.items():
         if layer_name=="pdk_config":
             continue

--- a/import_gdsii/__init__.py
+++ b/import_gdsii/__init__.py
@@ -341,6 +341,7 @@ def get_pdk_list(self, context):
 
 def get_color_schemes(self, context):
     """Dynamically generate color scheme list based on selected PDK"""
+    # TODO: Load only when accessing list or when opening file explorer, not every refresh. Or add a refresh button
 
     pdk = getattr(context.scene, 'gdsii_pdk_selection', 'IHP_SG13G2')
     addon_dir = Path(__file__).parent
@@ -410,7 +411,7 @@ class GDSIIPreImportDialog(bpy.types.Operator):
             default_color = addon_dir / pdk_info['color_path'] / f"{pdk_info['def_color']}.yaml"
             if default_color.exists():
                 self.custom_color_path = str(default_color)
-    # TODO: don't use os.join and use this syntax instead everywhere
+                
     def draw(self, context):
         layout = self.layout
 

--- a/import_gdsii/__init__.py
+++ b/import_gdsii/__init__.py
@@ -36,7 +36,7 @@ def load_pdk_configs(configs_dir=Path(__file__).parent / "configs"):
 
     for config_path in configs_dir.iterdir():
         if not(config_path.is_file() and
-               config_path.suffix.lower() in [".yaml, .yml"]):
+               config_path.suffix.lower() in [".yaml", ".yml"]):
             continue
         
         file_name = config_path.stem
@@ -64,7 +64,6 @@ def load_pdk_configs(configs_dir=Path(__file__).parent / "configs"):
         pdks[key].setdefault("name", key)
         pdks[key].setdefault("description", key)
         pdks[key].setdefault("def_color", "")
-
     # Sort "pdks" dictionary
     if pdk_order is None:
         return dict(sorted(pdks.items()))
@@ -78,7 +77,7 @@ def load_pdk_configs(configs_dir=Path(__file__).parent / "configs"):
                 if k not in pdk_order
             }
             sorted_pdks.update(dict(sorted(remaining.items())))
-        elif item in pdks:
+        elif item in pdks.keys():
             sorted_pdks[item] = pdks[item]
     return sorted_pdks
 

--- a/import_gdsii/__init__.py
+++ b/import_gdsii/__init__.py
@@ -32,6 +32,7 @@ import yaml
 # PDK Configuration paths
 def load_pdk_configs(configs_dir=Path(__file__).parent / "configs"):
     pdks = {}
+    pdk_order = None
 
     for config_path in configs_dir.iterdir():
         if not(config_path.is_file() and
@@ -39,6 +40,13 @@ def load_pdk_configs(configs_dir=Path(__file__).parent / "configs"):
             continue
         
         file_name = config_path.stem
+
+        # Get pdk_order
+        if file_name == "_config_order":
+            with open(config_path) as f:
+                pdk_order = yaml.safe_load(f)
+            continue
+
         key = file_name.upper().replace('-', '_') # Expected key format
 
         with open(config_path) as f:
@@ -57,11 +65,22 @@ def load_pdk_configs(configs_dir=Path(__file__).parent / "configs"):
         pdks[key].setdefault("description", key)
         pdks[key].setdefault("def_color", "")
 
-    # Return sorted "pdks" dictionary by "order" and then alphabetically
-    return dict(sorted(
-        pdks.items(),
-        key=lambda kv: (kv[1]["order"], kv[0])
-    ))
+    # Sort "pdks" dictionary
+    if pdk_order is None:
+        return dict(sorted(pdks.items()))
+    
+    sorted_pdks = {}
+    for item in pdk_order:
+        if item=="_": # Get all pdks not listed in pdk_order
+            remaining = {
+                k: v
+                for k, v in pdks.items()
+                if k not in pdk_order
+            }
+            sorted_pdks.update(dict(sorted(remaining.items())))
+        elif item in pdks:
+            sorted_pdks[item] = pdks[item]
+    return sorted_pdks
 
 PDK_CONFIGS = load_pdk_configs()
 

--- a/import_gdsii/configs/_config_order.yaml
+++ b/import_gdsii/configs/_config_order.yaml
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: 2025 aesc silicon
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+- _
+- ihp-sg13g2
+- ihp-sg13cmos5l
+- sky130
+- gf180mcu
+- siepic
+- lnoi400

--- a/import_gdsii/configs/gf180mcu.yaml
+++ b/import_gdsii/configs/gf180mcu.yaml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-file_config:
+pdk_config:
   name: GlobalFoundries GF180MCU PDK
   description: GlobalFoundries GF180MCU 180nm process
   order: 4

--- a/import_gdsii/configs/gf180mcu.yaml
+++ b/import_gdsii/configs/gf180mcu.yaml
@@ -2,6 +2,11 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+file_config:
+  name: GlobalFoundries GF180MCU PDK
+  description: GlobalFoundries GF180MCU 180nm process
+  order: 4
+
 Comp:
   index: 22
   type: 0

--- a/import_gdsii/configs/gf180mcu.yaml
+++ b/import_gdsii/configs/gf180mcu.yaml
@@ -6,6 +6,7 @@ pdk_config:
   name: GlobalFoundries GF180MCU PDK
   description: GlobalFoundries GF180MCU 180nm process
   order: 4
+  def_color: realistic
 
 Comp:
   index: 22

--- a/import_gdsii/configs/gf180mcu.yaml
+++ b/import_gdsii/configs/gf180mcu.yaml
@@ -5,7 +5,6 @@
 pdk_config:
   name: GlobalFoundries GF180MCU PDK
   description: GlobalFoundries GF180MCU 180nm process
-  order: 4
   def_color: realistic
 
 Comp:

--- a/import_gdsii/configs/ihp-sg13cmos5l.yaml
+++ b/import_gdsii/configs/ihp-sg13cmos5l.yaml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-file_config:
+pdk_config:
   name: IHP Open PDK SG13CMOS5L
   description: IHP SG13CMOS5L 130nm CMOS5L process
   order: 2

--- a/import_gdsii/configs/ihp-sg13cmos5l.yaml
+++ b/import_gdsii/configs/ihp-sg13cmos5l.yaml
@@ -2,6 +2,11 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+file_config:
+  name: IHP Open PDK SG13CMOS5L
+  description: IHP SG13CMOS5L 130nm CMOS5L process
+  order: 2
+
 Activ:
   index: 1
   type: 0

--- a/import_gdsii/configs/ihp-sg13cmos5l.yaml
+++ b/import_gdsii/configs/ihp-sg13cmos5l.yaml
@@ -5,7 +5,6 @@
 pdk_config:
   name: IHP Open PDK SG13CMOS5L
   description: IHP SG13CMOS5L 130nm CMOS5L process
-  order: 2
   def_color: realistic
 
 Activ:

--- a/import_gdsii/configs/ihp-sg13cmos5l.yaml
+++ b/import_gdsii/configs/ihp-sg13cmos5l.yaml
@@ -6,6 +6,7 @@ pdk_config:
   name: IHP Open PDK SG13CMOS5L
   description: IHP SG13CMOS5L 130nm CMOS5L process
   order: 2
+  def_color: realistic
 
 Activ:
   index: 1

--- a/import_gdsii/configs/ihp-sg13g2.yaml
+++ b/import_gdsii/configs/ihp-sg13g2.yaml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-file_config:
+pdk_config:
   name: IHP Open PDK SG13G2
   description: IHP SG13G2 130nm BiCMOS process
   order: 1

--- a/import_gdsii/configs/ihp-sg13g2.yaml
+++ b/import_gdsii/configs/ihp-sg13g2.yaml
@@ -2,6 +2,11 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+file_config:
+  name: IHP Open PDK SG13G2
+  description: IHP SG13G2 130nm BiCMOS process
+  order: 1
+
 Activ:
   index: 1
   type: 0

--- a/import_gdsii/configs/ihp-sg13g2.yaml
+++ b/import_gdsii/configs/ihp-sg13g2.yaml
@@ -6,6 +6,7 @@ pdk_config:
   name: IHP Open PDK SG13G2
   description: IHP SG13G2 130nm BiCMOS process
   order: 1
+  def_color: realistic
 
 Activ:
   index: 1

--- a/import_gdsii/configs/ihp-sg13g2.yaml
+++ b/import_gdsii/configs/ihp-sg13g2.yaml
@@ -5,7 +5,6 @@
 pdk_config:
   name: IHP Open PDK SG13G2
   description: IHP SG13G2 130nm BiCMOS process
-  order: 1
   def_color: realistic
 
 Activ:

--- a/import_gdsii/configs/lnoi400.yaml
+++ b/import_gdsii/configs/lnoi400.yaml
@@ -11,6 +11,11 @@
 #   - 2 µm SiO2 upper cladding above the LN device layer
 # Only patterned layers have GDS index/type pairs and are extruded below.
 
+pdk_config:
+  name: Luxtelligence LNOI400 PDK
+  description: Luxtelligence LNOI400 thin-film lithium niobate (X-cut, 400 nm LN, 200 nm etch) photonics PDK
+  order: 6
+
 # Patterned LN ridge waveguide (200 nm ridge on top of slab)
 LN_RIDGE:
   index: 2

--- a/import_gdsii/configs/lnoi400.yaml
+++ b/import_gdsii/configs/lnoi400.yaml
@@ -13,7 +13,9 @@
 
 pdk_config:
   name: Luxtelligence LNOI400 PDK
-  description: Luxtelligence LNOI400 thin-film lithium niobate (X-cut, 400 nm LN, 200 nm etch) photonics PDK
+  description: >
+    Luxtelligence LNOI400 thin-film lithium niobate (X-cut, 400 nm LN, 200 nm etch)
+    photonics PDK
   order: 6
   def_color: realistic
 

--- a/import_gdsii/configs/lnoi400.yaml
+++ b/import_gdsii/configs/lnoi400.yaml
@@ -15,6 +15,7 @@ pdk_config:
   name: Luxtelligence LNOI400 PDK
   description: Luxtelligence LNOI400 thin-film lithium niobate (X-cut, 400 nm LN, 200 nm etch) photonics PDK
   order: 6
+  def_color: realistic
 
 # Patterned LN ridge waveguide (200 nm ridge on top of slab)
 LN_RIDGE:

--- a/import_gdsii/configs/lnoi400.yaml
+++ b/import_gdsii/configs/lnoi400.yaml
@@ -16,7 +16,6 @@ pdk_config:
   description: >
     Luxtelligence LNOI400 thin-film lithium niobate (X-cut, 400 nm LN, 200 nm etch)
     photonics PDK
-  order: 6
   def_color: realistic
 
 # Patterned LN ridge waveguide (200 nm ridge on top of slab)

--- a/import_gdsii/configs/siepic.yaml
+++ b/import_gdsii/configs/siepic.yaml
@@ -7,7 +7,7 @@
 # Stack assumes a 220 nm Si device layer on buried oxide, with SiN above the Si
 # in the upper cladding, then TiW heater (M1), tungsten via (VC), and Al routing (M2).
 
-file_config:
+pdk_config:
   name: SiEPIC EBeam PDK
   description: SiEPIC EBeam silicon photonics PDK (220 nm SOI)
   order: 5

--- a/import_gdsii/configs/siepic.yaml
+++ b/import_gdsii/configs/siepic.yaml
@@ -7,6 +7,11 @@
 # Stack assumes a 220 nm Si device layer on buried oxide, with SiN above the Si
 # in the upper cladding, then TiW heater (M1), tungsten via (VC), and Al routing (M2).
 
+file_config:
+  name: SiEPIC EBeam PDK
+  description: SiEPIC EBeam silicon photonics PDK (220 nm SOI)
+  order: 5
+
 # 220 nm patterned silicon waveguide layer
 Si:
   index: 1

--- a/import_gdsii/configs/siepic.yaml
+++ b/import_gdsii/configs/siepic.yaml
@@ -10,7 +10,6 @@
 pdk_config:
   name: SiEPIC EBeam PDK
   description: SiEPIC EBeam silicon photonics PDK (220 nm SOI)
-  order: 5
   def_color: realistic
 
 # 220 nm patterned silicon waveguide layer

--- a/import_gdsii/configs/siepic.yaml
+++ b/import_gdsii/configs/siepic.yaml
@@ -11,6 +11,7 @@ pdk_config:
   name: SiEPIC EBeam PDK
   description: SiEPIC EBeam silicon photonics PDK (220 nm SOI)
   order: 5
+  def_color: realistic
 
 # 220 nm patterned silicon waveguide layer
 Si:

--- a/import_gdsii/configs/sky130.yaml
+++ b/import_gdsii/configs/sky130.yaml
@@ -2,6 +2,11 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+file_config:
+  name: SkyWater SKY130 PDK
+  description: SkyWater SKY130 130nm process
+  order: 3
+
 nwell:
   index: 64
   type: 20

--- a/import_gdsii/configs/sky130.yaml
+++ b/import_gdsii/configs/sky130.yaml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-file_config:
+pdk_config:
   name: SkyWater SKY130 PDK
   description: SkyWater SKY130 130nm process
   order: 3

--- a/import_gdsii/configs/sky130.yaml
+++ b/import_gdsii/configs/sky130.yaml
@@ -5,7 +5,6 @@
 pdk_config:
   name: SkyWater SKY130 PDK
   description: SkyWater SKY130 130nm process
-  order: 3
   def_color: realistic
 
 nwell:

--- a/import_gdsii/configs/sky130.yaml
+++ b/import_gdsii/configs/sky130.yaml
@@ -6,6 +6,7 @@ pdk_config:
   name: SkyWater SKY130 PDK
   description: SkyWater SKY130 130nm process
   order: 3
+  def_color: realistic
 
 nwell:
   index: 64

--- a/scripts/internal/check_configs.py
+++ b/scripts/internal/check_configs.py
@@ -19,7 +19,7 @@ for process in pdks.glob('*yaml'):
 
     pdk_file = yaml.safe_load(process.read_text(encoding='utf-8'))
     validate(pdk_file, pdk_schema)
-    pdk_layers = set(pdk_file.keys())
+    pdk_layers = set(key for key in pdk_file.keys() if not key=="pdk_config")
 
     for color in (pdks / f"colors/{process.stem}").glob('*yaml'):
         print(f"  Found color schema: {color.stem}")

--- a/scripts/internal/check_configs.py
+++ b/scripts/internal/check_configs.py
@@ -11,6 +11,9 @@ with open(script_dir / 'layer-config.schema.json', encoding='utf-8') as f:
 with open(script_dir / 'color-schema.schema.json', encoding='utf-8') as f:
     color_schema = json.load(f)
 
+with open(script_dir / 'pdk-order.schema.json', encoding='utf-8') as f:
+    order_schema = json.load(f)
+
 
 project_dir = script_dir.parent.parent
 pdks = project_dir / "import_gdsii/configs"
@@ -18,6 +21,10 @@ for process in pdks.glob('*yaml'):
     print(f"Found process: {process.stem}")
 
     pdk_file = yaml.safe_load(process.read_text(encoding='utf-8'))
+    if process.name == "_config_order.yaml":
+        validate(pdk_file, order_schema)
+        continue
+    
     validate(pdk_file, pdk_schema)
     pdk_layers = set(key for key in pdk_file.keys() if not key=="pdk_config")
 

--- a/scripts/internal/layer-config.schema.json
+++ b/scripts/internal/layer-config.schema.json
@@ -8,6 +8,24 @@
       "type": "object",
       "required": ["index", "type", "z", "height"],
       "properties": {
+        "pdk_config": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            },
+            "order": {
+              "type": "integer"
+            },
+            "def_color": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
         "index": {
           "type": "integer",
           "description": "Layer index number",

--- a/scripts/internal/layer-config.schema.json
+++ b/scripts/internal/layer-config.schema.json
@@ -3,29 +3,32 @@
   "title": "Layer Configuration",
   "description": "Schema for validating layer configuration YAML files with index, type, z-position, and height",
   "type": "object",
+  "properties": {
+    "pdk_config": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "order": {
+          "type": "integer"
+        },
+        "def_color": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+
   "patternProperties": {
-    "^[A-Za-z0-9_]+$": {
+    "^(?!pdk_config$)[A-Za-z0-9_]+$": {
       "type": "object",
       "required": ["index", "type", "z", "height"],
       "properties": {
-        "pdk_config": {
-          "type": "object",
-          "properties": {
-            "name": {
-              "type": "string"
-            },
-            "description": {
-              "type": "string"
-            },
-            "order": {
-              "type": "integer"
-            },
-            "def_color": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false
-        },
         "index": {
           "type": "integer",
           "description": "Layer index number",

--- a/scripts/internal/pdk-order.schema.json
+++ b/scripts/internal/pdk-order.schema.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "PDK Order",
+  "description": "Schema for validating PDK order YAML files with array of names inside",
+  "type": "array",
+  "items": {
+    "type": "string"
+  }
+}


### PR DESCRIPTION
Removes hardcoded presets, reading the files present at "config" folder.
Allows for users to add their custom presets and be readily available from Blender UI.

A set of new properties have been added to the "config" YAML files under "pdk_config", where name, description, order and default color can be set.
"Order" are integers. Default value is 0. If same value is set, then it's ordered alphabetically.
Since I set order of existing presets greater than 0, any new custom preset added by the user will take preference in the list.

I'm thinking next step to polish stuff is to not have a pre-import popup, and instead choose pdk and color from the import window.

TODO: Update readme.md and schema.json, add "def_color" to presets and make default def_color=""