### PR TITLE
Add dynamic PDK preset support

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,38 @@ Each layer requires:
 - `output_file` - Path for the merged output GDS file
 - `input.gds` - Input GDS file to process
 
+### PDK Configuration
+
+Every layer stack in `import_gdsii/configs` is offered as a PDK in Blender's import
+dialog. Dropping an additional YAML file into that directory, together with a color
+schema directory of the same name below `configs/colors`, is enough to add a custom
+PDK. It shows up the next time the import dialog is opened.
+
+An optional `pdk_config` section describes the PDK itself instead of one of its
+layers:
+
+```yaml
+pdk_config:
+  name: SkyWater SKY130 PDK
+  description: SkyWater SKY130 130nm process
+  def_color: realistic
+```
+
+All fields are optional:
+
+* `name` - Name shown in the PDK list. Defaults to the config file name
+* `description` - Tooltip shown for the PDK. Defaults to the config file name
+* `def_color` - Color schema pre-selected for this PDK. Defaults to the first
+  schema in alphabetical order
+
+`configs/_config_order.yaml` lists the config file names in the order they appear
+in the PDK list. Files missing from this list are appended in alphabetical order:
+
+```yaml
+- ihp-sg13g2
+- sky130
+```
+
 ### Color Schema Configuration
 
 Color schemas are defined in YAML format and control the material appearance of each layer.

--- a/import_gdsii/__init__.py
+++ b/import_gdsii/__init__.py
@@ -29,39 +29,82 @@ import yaml
 # PDK DEFINITIONS
 # ============================================================================
 
-# PDK Configuration paths
-PDK_CONFIGS = {
-    'IHP_SG13G2': {
-        'name': 'IHP Open PDK (SG13G2)',
-        'config_path': 'configs/ihp-sg13g2.yaml',
-        'color_path': 'configs/colors/ihp-sg13g2/'
-    },
-    'IHP_SG13CMOS5L': {
-        'name': 'IHP Open PDK (SG13CMOS5L)',
-        'config_path': 'configs/ihp-sg13cmos5l.yaml',
-        'color_path': 'configs/colors/ihp-sg13cmos5l/'
-    },
-    'SKY130': {
-        'name': 'SkyWater SKY130 PDK',
-        'config_path': 'configs/sky130.yaml',
-        'color_path': 'configs/colors/sky130/'
-    },
-    'GF180MCU': {
-        'name': 'GlobalFoundries GF180MCU PDK',
-        'config_path': 'configs/gf180mcu.yaml',
-        'color_path': 'configs/colors/gf180mcu/'
-    },
-    'SIEPIC_EBEAM': {
-        'name': 'SiEPIC EBeam PDK',
-        'config_path': 'configs/siepic.yaml',
-        'color_path': 'configs/colors/siepic/'
-    },
-    'LNOI400': {
-        'name': 'Luxtelligence LNOI400 PDK',
-        'config_path': 'configs/lnoi400.yaml',
-        'color_path': 'configs/colors/lnoi400/'
-    },
-}
+# Directory holding the PDK layer stacks and their color schemes
+CONFIGS_DIR = Path(__file__).parent / "configs"
+
+# Config file listing the PDKs in the order they appear in the user interface
+PDK_ORDER_FILE = "_config_order"
+
+# PDK configs read from CONFIGS_DIR, refreshed whenever the import dialog opens
+_pdk_configs = {}
+
+
+def _pdk_key(file_name):
+    """Convert a config file name into the identifier used for its PDK"""
+    return file_name.upper().replace('-', '_')
+
+
+def _sort_pdk_configs(pdks, order):
+    """Sort PDKs as listed in the order file
+
+    Entries are config file names. PDKs missing from the list are appended
+    in alphabetical order.
+    """
+    sorted_pdks = {}
+    for entry in order:
+        key = _pdk_key(entry)
+        if key in pdks:
+            sorted_pdks[key] = pdks[key]
+    sorted_pdks.update({key: pdks[key] for key in sorted(pdks)
+                        if key not in sorted_pdks})
+
+    return sorted_pdks
+
+
+def load_pdk_configs(configs_dir=CONFIGS_DIR):
+    """Read all PDK configs from configs_dir and cache them"""
+    global _pdk_configs
+
+    pdks = {}
+    order = []
+    for config_path in sorted(configs_dir.iterdir()):
+        if not config_path.is_file() or config_path.suffix.lower() not in ('.yaml', '.yml'):
+            continue
+
+        try:
+            config = yaml.safe_load(config_path.read_text(encoding='utf-8'))
+        except yaml.YAMLError as error:
+            print(f"⚠ Ignoring malformed config {config_path.name}: {error}")
+            continue
+
+        if config_path.stem == PDK_ORDER_FILE:
+            order = config or []
+            continue
+
+        if not isinstance(config, dict):
+            print(f"⚠ Ignoring config without layers: {config_path.name}")
+            continue
+
+        # Optional metadata describing the PDK itself instead of one of its layers
+        metadata = config.get('pdk_config') or {}
+        key = _pdk_key(config_path.stem)
+        pdks[key] = {
+            'config_path': config_path,
+            'color_path': configs_dir / 'colors' / config_path.stem,
+            'name': metadata.get('name', key),
+            'description': metadata.get('description', key),
+            'def_color': metadata.get('def_color', ''),
+        }
+
+    _pdk_configs = _sort_pdk_configs(pdks, order)
+    return _pdk_configs
+
+
+def get_pdk_configs():
+    """Return the known PDK configs and read them from disk on first use"""
+    if not _pdk_configs:
+        load_pdk_configs()
+    return _pdk_configs
 
 
 # ============================================================================
@@ -337,21 +380,30 @@ def create_extruded_layer(report, gds_path, z, height, layer, name, color, mat_n
 # PRE-IMPORT PDK SELECTION DIALOG
 # ============================================================================
 
+def get_pdk_list(self, context):
+    """Dynamically generate PDK list based on the available configs"""
+    return [(key, pdk['name'], pdk['description'])
+            for key, pdk in get_pdk_configs().items()]
+
+
 def get_color_schemes(self, context):
     """Dynamically generate color scheme list based on selected PDK"""
-    items = []
+    pdk_configs = get_pdk_configs()
+    pdk = getattr(context.scene, 'gdsii_pdk_selection', next(iter(pdk_configs), ''))
+    pdk_info = pdk_configs.get(pdk)
+    if pdk_info is None:
+        return []
 
-    pdk = getattr(context.scene, 'gdsii_pdk_selection', 'IHP_SG13G2')
-    addon_dir = Path(__file__).parent
-    color_path = addon_dir / PDK_CONFIGS.get(pdk, {}).get('color_path', pdk)
-    schemes = [('realistic', 'Realistic', 'Realistic color scheme')]
-    for file in color_path.glob('*yaml'):
-        # Make sure realistic is the default choice
-        if file.stem == 'realistic':
-            continue
+    schemes = []
+    for file in sorted(pdk_info['color_path'].glob('*.yaml')):
         color_file = yaml.safe_load(file.read_text(encoding='utf-8'))
-        schemes.append((file.stem, color_file.get('name', file.stem),
-                       color_file.get('description', file.stem)))
+        scheme = (file.stem, color_file.get('name', file.stem),
+                  color_file.get('description', file.stem))
+        # Make sure the PDK's default scheme is the first choice
+        if file.stem == pdk_info['def_color']:
+            schemes.insert(0, scheme)
+        else:
+            schemes.append(scheme)
     return schemes
 
 
@@ -364,15 +416,7 @@ class GDSIIPreImportDialog(bpy.types.Operator):
     pdk_selection: EnumProperty(
         name="PDK",
         description="Process Design Kit to use for layer stack",
-        items=[
-            ('IHP_SG13G2', "IHP Open PDK SG13G2", "IHP SG13G2 130nm BiCMOS process"),
-            ('IHP_SG13CMOS5L', "IHP Open PDK SG13CMOS5L", "IHP SG13CMOS5L 130nm CMOS5L process"),
-            ('SKY130', "SkyWater SKY130 PDK", "SkyWater SKY130 130nm process"),
-            ('GF180MCU', "GlobalFoundries GF180MCU PDK", "GlobalFoundries GF180MCU 180nm process"),
-            ('SIEPIC_EBEAM', "SiEPIC EBeam PDK", "SiEPIC EBeam silicon photonics PDK (220 nm SOI)"),
-            ('LNOI400', "Luxtelligence LNOI400 PDK", "Luxtelligence LNOI400 thin-film lithium niobate (X-cut, 400 nm LN, 200 nm etch) photonics PDK"),
-        ],
-        default='IHP_SG13G2',
+        items=get_pdk_list,
     )
 
     use_custom_config: BoolProperty(
@@ -396,22 +440,25 @@ class GDSIIPreImportDialog(bpy.types.Operator):
     )
 
     def invoke(self, context, event):
+        # Pick up PDKs added since the last import
+        load_pdk_configs()
         # Set default config path based on PDK selection
         self.update_config_path()
         return context.window_manager.invoke_props_dialog(self, width=400)
 
     def update_config_path(self):
         """Update config path based on selected PDK"""
-        if not self.use_custom_config and self.pdk_selection in PDK_CONFIGS:
-            pdk_info = PDK_CONFIGS[self.pdk_selection]
-            # Try to find config relative to add-on directory
-            addon_dir = Path(__file__).parent
-            config_file = addon_dir / pdk_info['config_path']
-            if config_file.exists():
-                self.custom_config_path = str(config_file)
-            default_color = addon_dir / pdk_info['color_path'] / 'realistic.yaml'
-            if default_color.exists():
-                self.custom_color_path = str(default_color)
+        pdk_info = get_pdk_configs().get(self.pdk_selection)
+        if self.use_custom_config or pdk_info is None:
+            return
+
+        if pdk_info['config_path'].exists():
+            self.custom_config_path = str(pdk_info['config_path'])
+        if not pdk_info['def_color']:
+            return
+        default_color = pdk_info['color_path'] / f"{pdk_info['def_color']}.yaml"
+        if default_color.exists():
+            self.custom_color_path = str(default_color)
 
     def draw(self, context):
         layout = self.layout
@@ -435,8 +482,9 @@ class GDSIIPreImportDialog(bpy.types.Operator):
             if not Path(self.custom_config_path).is_file() or not Path(self.custom_color_path).is_file():
                 box.label(text="Fix highlighted paths before importing", icon='ERROR')
         else:
-            pdk_info = PDK_CONFIGS.get(self.pdk_selection, {})
-            box.label(text=f"Using: {pdk_info.get('config_path', 'N/A')}", icon='INFO')
+            pdk_info = get_pdk_configs().get(self.pdk_selection, {})
+            config_path = pdk_info.get('config_path')
+            box.label(text=f"Using: {config_path.name if config_path else 'N/A'}", icon='INFO')
 
     def execute(self, context):
         # Store PDK settings in scene for the importer to use
@@ -595,8 +643,9 @@ class ImportGDSII(bpy.types.Operator, ImportHelper):
         box = layout.box()
         box.label(text="Selected PDK:", icon='PRESET')
         if not use_custom:
-            pdk = getattr(context.scene, 'gdsii_pdk_selection', 'IHP_SG13G2')
-            pdk_name = PDK_CONFIGS.get(pdk, {}).get('name', pdk)
+            pdk_configs = get_pdk_configs()
+            pdk = getattr(context.scene, 'gdsii_pdk_selection', next(iter(pdk_configs), ''))
+            pdk_name = pdk_configs.get(pdk, {}).get('name', pdk)
         else:
             pdk_name = "Custom"
         box.label(text=pdk_name)
@@ -608,7 +657,9 @@ class ImportGDSII(bpy.types.Operator, ImportHelper):
         """Main import function"""
         try:
             # Get PDK settings from scene
-            pdk_selection = getattr(context.scene, 'gdsii_pdk_selection', 'IHP_SG13G2')
+            pdk_configs = get_pdk_configs()
+            pdk_selection = getattr(context.scene, 'gdsii_pdk_selection',
+                                    next(iter(pdk_configs), ''))
             use_custom = getattr(context.scene, 'gdsii_use_custom_config', False)
             custom_config_path = getattr(context.scene, 'gdsii_custom_config_path', '')
             custom_color_path = getattr(context.scene, 'gdsii_custom_color_path', '')
@@ -618,9 +669,11 @@ class ImportGDSII(bpy.types.Operator, ImportHelper):
                 yamlfile = Path(custom_config_path)
             else:
                 # Use built-in PDK config
-                pdk_info = PDK_CONFIGS.get(pdk_selection, {})
-                addon_dir = Path(__file__).parent
-                yamlfile = addon_dir / pdk_info.get('config_path', 'configs/ihp-sg13g2.yaml')
+                pdk_info = pdk_configs.get(pdk_selection)
+                if pdk_info is None:
+                    self.report({'ERROR'}, f"Unknown PDK: {pdk_selection}")
+                    return {'CANCELLED'}
+                yamlfile = pdk_info['config_path']
 
             # Load layer stack configuration
             if not yamlfile.is_file():
@@ -628,6 +681,8 @@ class ImportGDSII(bpy.types.Operator, ImportHelper):
                 return {'CANCELLED'}
 
             layerstack = yaml.safe_load(yamlfile.read_text(encoding='utf-8'))
+            # PDK metadata describes the file itself and is not a layer
+            layerstack.pop('pdk_config', None)
 
             # Setup crop box if enabled
             crop_box = None
@@ -666,12 +721,10 @@ class ImportGDSII(bpy.types.Operator, ImportHelper):
             if self.setup_scene:
                 setup_chip_scene(bbox_min[0], bbox_min[1], bbox_max[0], bbox_max[1], collection)
 
-            addon_dir = Path(__file__).parent
             if use_custom:
                 colorfile = Path(custom_color_path)
             else:
-                color_dir = addon_dir / pdk_info.get('color_path', 'configs/colors/ihp-sg13g2')
-                colorfile = color_dir / f"{self.color_scheme}.yaml"
+                colorfile = pdk_info['color_path'] / f"{self.color_scheme}.yaml"
             if not colorfile.is_file():
                 self.report({'ERROR'}, f"Color schema file not found: {colorfile}")
                 return {'CANCELLED'}
@@ -750,7 +803,8 @@ def menu_func_import(self, context):
 
 # Properties to store PDK settings in scene
 def register_properties():
-    bpy.types.Scene.gdsii_pdk_selection = StringProperty(default='IHP_SG13G2')
+    bpy.types.Scene.gdsii_pdk_selection = StringProperty(
+        default=next(iter(get_pdk_configs()), ''))
     bpy.types.Scene.gdsii_use_custom_config = BoolProperty(default=False)
     bpy.types.Scene.gdsii_custom_config_path = StringProperty(default='')
     bpy.types.Scene.gdsii_custom_color_path = StringProperty(default='')

--- a/import_gdsii/configs/_config_order.yaml
+++ b/import_gdsii/configs/_config_order.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: 2025 aesc silicon
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# PDKs in the order they appear in Blender. Config files missing from this
+# list are appended in alphabetical order.
+- ihp-sg13g2
+- ihp-sg13cmos5l
+- sky130
+- gf180mcu
+- siepic
+- lnoi400

--- a/import_gdsii/configs/gf180mcu.yaml
+++ b/import_gdsii/configs/gf180mcu.yaml
@@ -2,6 +2,11 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+pdk_config:
+  name: GlobalFoundries GF180MCU PDK
+  description: GlobalFoundries GF180MCU 180nm process
+  def_color: realistic
+
 Comp:
   index: 22
   type: 0

--- a/import_gdsii/configs/ihp-sg13cmos5l.yaml
+++ b/import_gdsii/configs/ihp-sg13cmos5l.yaml
@@ -2,6 +2,11 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+pdk_config:
+  name: IHP Open PDK SG13CMOS5L
+  description: IHP SG13CMOS5L 130nm CMOS5L process
+  def_color: realistic
+
 Activ:
   index: 1
   type: 0

--- a/import_gdsii/configs/ihp-sg13g2.yaml
+++ b/import_gdsii/configs/ihp-sg13g2.yaml
@@ -2,6 +2,11 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+pdk_config:
+  name: IHP Open PDK SG13G2
+  description: IHP SG13G2 130nm BiCMOS process
+  def_color: realistic
+
 Activ:
   index: 1
   type: 0

--- a/import_gdsii/configs/lnoi400.yaml
+++ b/import_gdsii/configs/lnoi400.yaml
@@ -11,6 +11,13 @@
 #   - 2 µm SiO2 upper cladding above the LN device layer
 # Only patterned layers have GDS index/type pairs and are extruded below.
 
+pdk_config:
+  name: Luxtelligence LNOI400 PDK
+  description: >-
+    Luxtelligence LNOI400 thin-film lithium niobate (X-cut, 400 nm LN, 200 nm etch)
+    photonics PDK
+  def_color: realistic
+
 # Patterned LN ridge waveguide (200 nm ridge on top of slab)
 LN_RIDGE:
   index: 2

--- a/import_gdsii/configs/siepic.yaml
+++ b/import_gdsii/configs/siepic.yaml
@@ -7,6 +7,11 @@
 # Stack assumes a 220 nm Si device layer on buried oxide, with SiN above the Si
 # in the upper cladding, then TiW heater (M1), tungsten via (VC), and Al routing (M2).
 
+pdk_config:
+  name: SiEPIC EBeam PDK
+  description: SiEPIC EBeam silicon photonics PDK (220 nm SOI)
+  def_color: realistic
+
 # 220 nm patterned silicon waveguide layer
 Si:
   index: 1

--- a/import_gdsii/configs/sky130.yaml
+++ b/import_gdsii/configs/sky130.yaml
@@ -2,6 +2,11 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+pdk_config:
+  name: SkyWater SKY130 PDK
+  description: SkyWater SKY130 130nm process
+  def_color: realistic
+
 nwell:
   index: 64
   type: 20

--- a/scripts/internal/check_configs.py
+++ b/scripts/internal/check_configs.py
@@ -11,6 +11,9 @@ with open(script_dir / 'layer-config.schema.json', encoding='utf-8') as f:
 with open(script_dir / 'color-schema.schema.json', encoding='utf-8') as f:
     color_schema = json.load(f)
 
+with open(script_dir / 'pdk-order.schema.json', encoding='utf-8') as f:
+    order_schema = json.load(f)
+
 
 project_dir = script_dir.parent.parent
 pdks = project_dir / "import_gdsii/configs"
@@ -18,8 +21,15 @@ for process in pdks.glob('*yaml'):
     print(f"Found process: {process.stem}")
 
     pdk_file = yaml.safe_load(process.read_text(encoding='utf-8'))
+    if process.stem == "_config_order":
+        validate(pdk_file, order_schema)
+        for entry in pdk_file:
+            assert (pdks / f"{entry}.yaml").is_file(), \
+                f"PDK order lists \"{entry}\" without a matching config file."
+        continue
+
     validate(pdk_file, pdk_schema)
-    pdk_layers = set(pdk_file.keys())
+    pdk_layers = set(pdk_file.keys()) - {"pdk_config"}
 
     for color in (pdks / f"colors/{process.stem}").glob('*yaml'):
         print(f"  Found color schema: {color.stem}")

--- a/scripts/internal/layer-config.schema.json
+++ b/scripts/internal/layer-config.schema.json
@@ -3,8 +3,25 @@
   "title": "Layer Configuration",
   "description": "Schema for validating layer configuration YAML files with index, type, z-position, and height",
   "type": "object",
+  "properties": {
+    "pdk_config": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "def_color": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    }
+  },
   "patternProperties": {
-    "^[A-Za-z0-9_]+$": {
+    "^(?!pdk_config$)[A-Za-z0-9_]+$": {
       "type": "object",
       "required": ["index", "type", "z", "height"],
       "properties": {

--- a/scripts/internal/pdk-order.schema.json
+++ b/scripts/internal/pdk-order.schema.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "PDK Order",
+  "description": "Schema for validating PDK order YAML files with array of names inside",
+  "type": "array",
+  "items": {
+    "type": "string"
+  }
+}


### PR DESCRIPTION
Supersedes #41 by @Gerard-Taulats with the open review feedback addressed and a
cleaned up history. The commits keep his authorship.

The hardcoded PDK table is gone: every layer stack config in
`import_gdsii/configs` is offered as a preset, so users can add their own PDK by
dropping a config file next to the shipped ones together with a color schema
directory of the same name. The list is read once and refreshed whenever the
import dialog opens, so a new config shows up without restarting Blender.

A config file may describe itself in an optional `pdk_config` section (`name`,
`description`, `def_color`); everything falls back to the file name. The preset
order lives in `configs/_config_order.yaml`, so it no longer has to be
maintained across several files. Configs missing from that list are appended in
alphabetical order instead of being dropped.

Changes on top of #41:
* Order entries are matched against the PDK keys again — the list was silently
  ignored before, and the `_` placeholder is replaced by the fallback above
* Two `f"...{d["key"]}..."` fallbacks that are a `SyntaxError` before Python
  3.12 are gone; the config and color paths now come straight from the loaded
  config, and an unknown PDK is reported instead of raising
* `pdk_config` is dropped from the layer stack after loading instead of being
  skipped in every consumer
* Malformed or empty YAML files in the config directory are ignored with a
  warning instead of breaking the add-on
* `_config_order.yaml` entries without a config file now fail the config check
* Debug print, stale `IHP_SG13G2` fallbacks, the unused `order` schema field and
  the whitespace noise are removed

Note: the SiEPIC preset identifier changes from `SIEPIC_EBEAM` to `SIEPIC`,
since identifiers are derived from the config file name (`siepic.yaml`).

Tested with Blender 4.3.2: importing with a built-in PDK, with a custom config
and color schema, and with an unknown PDK stored in the scene, plus `tox` on
every commit.
