### PR TITLE
Import GDS files with KLayout only

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ BlenderGDS enables semiconductor layout visualization by importing GDSII files i
 
 ## Installation
 
-BlenderGDS requires **Blender 4.2 or later**. All Python dependencies (`gdstk`, `klayout`, `numpy`, `PyYAML`) are bundled inside the extension and installed automatically — no pip or terminal required.
+BlenderGDS requires **Blender 4.2 or later**. All Python dependencies (`klayout`, `numpy`, `PyYAML`) are bundled inside the extension and installed automatically — no pip or terminal required.
 
 ### Installing from Blender Extensions
 

--- a/import_gdsii/__init__.py
+++ b/import_gdsii/__init__.py
@@ -13,14 +13,14 @@ bl_info = {
     "category": "Import-Export",
 }
 
+import math
 import os
-import tempfile
 from pathlib import Path
 import bpy
+import bmesh
 from bpy.props import StringProperty, BoolProperty, FloatProperty, EnumProperty
 from bpy_extras.io_utils import ImportHelper
 import numpy as np
-import gdstk
 import klayout.db as db
 import yaml
 
@@ -267,102 +267,138 @@ def create_material(name, color):
     return mat
 
 
-def _create_merged_gds(gds_path, layerstack, tmp_dir):
-    """Merge all layers with KLayout and write the result to a GDS in tmp_dir."""
-    layout = db.Layout()
-    layout.read(str(gds_path))
-    top_cell = layout.top_cell()
+# KLayout prints polygons as "(x,y;x,y;...);(x,y;...)"
+_POLYGON_CHARS = str.maketrans({'(': None, ')': None, ';': ','})
 
-    merged_layout = db.Layout()
-    merged_layout.dbu = layout.dbu
-    merged_top_cell = merged_layout.create_cell(top_cell.name)
-
-    for data in layerstack.values():
-        layer = (data['index'], data['type'])
-        layer_index = layout.layer(*layer)
-        region = db.Region(top_cell.begin_shapes_rec(layer_index))
-        merged_top_cell.shapes(merged_layout.layer(*layer)).insert(region.merged())
-
-    merged_path = Path(tmp_dir) / "merged.gds"
-    merged_layout.write(str(merged_path))
-    return merged_path
+# Number of vertices above which a single layer slows down Blender noticeably
+VERTEX_WARN_LIMIT = 1000000
 
 
-def create_extruded_layer(report, gds_path, z, height, layer, name, color, mat_name=None, unit=1e-6, crop_box=None, offset=None):
+def _read_coordinates(text):
+    """Convert KLayout's polygon string into an array of integer coordinates"""
+    return np.fromstring(text.translate(_POLYGON_CHARS), sep=',',
+                         dtype=np.int64).reshape(-1, 2)
+
+
+def _triangles_to_mesh(region):
+    """Convert a region of triangles into welded vertices and triangle faces"""
+    text = region.to_s(-1)
+    if not text:
+        return np.empty((0, 2), dtype=np.int64), np.empty((0, 3), dtype=np.int64)
+
+    # Neighbouring triangles share their corners, so the vertices are welded
+    coords, inverse = np.unique(_read_coordinates(text), axis=0, return_inverse=True)
+    faces = inverse.reshape(-1, 3)
+
+    # A triangle whose corners fall onto the same vertex has no area
+    keep = ((faces[:, 0] != faces[:, 1]) & (faces[:, 1] != faces[:, 2])
+            & (faces[:, 0] != faces[:, 2]))
+    return coords, faces[keep]
+
+
+def _polygons_to_mesh(region):
+    """Convert a region of hole-free polygons into vertices and n-gon faces"""
+    text = region.to_s(-1)
+    if not text:
+        return np.empty((0, 2), dtype=np.int64), []
+
+    coords = _read_coordinates(text)
+    faces = []
+    start = 0
+    for polygon in text.split(');('):
+        end = start + polygon.count(';') + 1
+        faces.append(list(range(start, end)))
+        start = end
+    return coords, faces
+
+
+def create_extruded_layer(report, layout, top_cells, z, height, layer, name, color,
+                          mat_name=None, unit=1e-6, crop_box=None, offset=None,
+                          merge=True):
     """Create extruded geometry for a specific GDS layer"""
-    # Read and filter GDS
-    library = gdstk.read_gds(gds_path, unit=unit, filter={layer})
+    dbu = layout.dbu * 1e-6 / unit
 
-    # Merge and flatten all top-level cells
-    merged_cell = gdstk.Cell("MERGED")
-    for cell in library.top_level():
-        flattened = cell.flatten()
+    # Collect the layer from all top cells, including their sub cells
+    region = db.Region()
+    layer_index = layout.layer(*layer)
+    for cell in top_cells:
+        region.insert(cell.begin_shapes_rec(layer_index))
 
-        # Add polygons
-        merged_cell.add(*flattened.polygons)
-
-        # Convert paths to polygons
-        for path in flattened.paths:
-            merged_cell.add(*path.to_polygons())
-
-    # Apply crop if specified
     if crop_box is not None:
         x_min, y_min, x_max, y_max = crop_box
-        crop_rect = gdstk.rectangle((x_min, y_min), (x_max, y_max))
+        region &= db.Region(db.Box(
+            math.floor(x_min / dbu),
+            math.floor(y_min / dbu),
+            math.ceil(x_max / dbu),
+            math.ceil(y_max / dbu),
+        ))
 
-        # Filter polygons that intersect with crop region
-        cropped_polygons = []
-        for polygon in merged_cell.polygons:
-            # Use boolean AND operation to get intersection
-            result = gdstk.boolean(polygon, crop_rect, "and")
-            cropped_polygons.extend(result)
+    # Merging avoids overlapping faces, which Cycles renders as artifacts.
+    # Without it the polygons have to be taken as they are in the GDS, since
+    # KLayout otherwise merges them on the fly for every operation below.
+    if merge:
+        region.merge()
+    else:
+        region.merged_semantics = False
 
-        # Replace with cropped polygons
-        merged_cell = gdstk.Cell("MERGED")
-        merged_cell.add(*cropped_polygons)
-
-    polygon_count = len(merged_cell.polygons)
+    polygon_count = region.count()
     if polygon_count == 0:
         print(f"⚠ Layer {name}: No geometry found")
         return None
 
-    # Pre-allocate arrays for better performance
-    all_verts = []
-    all_faces = []
-    v_offset = 0
+    # Blender cannot fill a face with a hole, so KLayout triangulates those
+    # polygons. All others are kept as they are and triangulated further down.
+    tri_coords, tri_faces = _triangles_to_mesh(region.with_holes(0, True).delaunay())
+    poly_coords, poly_faces = _polygons_to_mesh(region.with_holes(0, False))
 
-    for polygon in merged_cell.polygons:
-        points = polygon.points
-        if offset is not None:
-            points = points - np.array(offset)
-        n = len(points)
+    coords = np.concatenate((tri_coords, poly_coords))
+    if offset is not None:
+        coords = coords - np.array([round(offset[0] / dbu), round(offset[1] / dbu)])
 
-        if n < 3:
-            continue
+    verts = np.empty((len(coords), 3), dtype=np.float64)
+    verts[:, :2] = coords * dbu
+    verts[:, 2] = z
 
-        # Build vertices
-        bottom = np.column_stack([points, np.full(n, z)])
-        top = np.column_stack([points, np.full(n, z + height)])
-        verts = np.vstack([bottom, top])
+    faces = tri_faces.tolist()
+    faces.extend([index + len(tri_coords) for index in face] for face in poly_faces)
 
-        all_verts.extend(verts.tolist())
+    if len(verts) > VERTEX_WARN_LIMIT:
+        report({'WARNING'}, f"{name}: {len(verts)} vertices may slow down Blender")
 
-        # Build faces
-        all_faces.append([v_offset + j for j in range(n)])
-        all_faces.append([v_offset + 2*n-1-j for j in range(n)])
-        all_faces.extend([[v_offset + j, v_offset + (j+1)%n, 
-                          v_offset + (j+1)%n + n, v_offset + j + n] 
-                         for j in range(n)])
-
-        v_offset += 2 * n
-
-    # Create mesh
+    # -----------------------------
+    # BUILD MESH
+    # -----------------------------
     mesh = bpy.data.meshes.new(name=f"M{name}")
-    mesh.from_pydata(all_verts, [], all_faces)
-    mesh.update()
+    mesh.from_pydata(verts.tolist(), [], faces)
+    if mesh.validate(verbose=False):
+        print(f"⚠ Layer {name}: Removed invalid geometry")
 
     obj = bpy.data.objects.new(name=f"L{name}", object_data=mesh)
     bpy.context.collection.objects.link(obj)
+
+    # -----------------------------
+    # EXTRUDE
+    # -----------------------------
+    bm = bmesh.new()
+    bm.from_mesh(mesh)
+
+    # Blender renders triangles and quads better than large n-gons
+    bmesh.ops.triangulate(bm, faces=bm.faces[:])
+    bmesh.ops.join_triangles(bm, faces=bm.faces[:],
+                             angle_face_threshold=math.pi / 4,
+                             angle_shape_threshold=math.pi)
+
+    extruded = bmesh.ops.extrude_face_region(bm, geom=bm.faces[:])
+    bmesh.ops.translate(
+        bm,
+        verts=[v for v in extruded['geom'] if isinstance(v, bmesh.types.BMVert)],
+        vec=(0, 0, height),
+    )
+    bmesh.ops.recalc_face_normals(bm, faces=bm.faces[:])
+
+    bm.to_mesh(mesh)
+    bm.free()
+    mesh.update()
 
     # Apply material
     mat = create_material(name if mat_name is None else mat_name, color)
@@ -371,8 +407,8 @@ def create_extruded_layer(report, gds_path, z, height, layer, name, color, mat_n
     else:
         obj.data.materials.append(mat)
 
-    print(f"✓ {name}: {polygon_count} polygons, {len(all_verts)} vertices")
-    report({'INFO'}, f"✓ {name}: {polygon_count} polygons, {len(all_verts)} vertices")
+    print(f"✓ {name}: {polygon_count} polygons, {len(verts)} vertices")
+    report({'INFO'}, f"✓ {name}: {polygon_count} polygons, {len(verts)} vertices")
     return obj
 
 
@@ -684,6 +720,15 @@ class ImportGDSII(bpy.types.Operator, ImportHelper):
             # PDK metadata describes the file itself and is not a layer
             layerstack.pop('pdk_config', None)
 
+            # Read the layout once and extract every layer from it
+            gds_layout = db.Layout()
+            gds_layout.read(filepath)
+            top_cells = gds_layout.top_cells()
+            if not top_cells:
+                self.report({'ERROR'}, f"No cell found in {Path(filepath).name}")
+                return {'CANCELLED'}
+            dbu = gds_layout.dbu * 1e-6 / self.unit_scale
+
             # Setup crop box if enabled
             crop_box = None
             crop_offset = None
@@ -702,10 +747,11 @@ class ImportGDSII(bpy.types.Operator, ImportHelper):
                 print(f"Cropping to region: X={self.crop_x}, Y={self.crop_y}, W={self.crop_width}, H={self.crop_height}")
             else:
                 # Determine chip dimensions for scene setup
-                lib = gdstk.read_gds(filepath, unit=self.unit_scale)
-                bboxes = [c.bounding_box() for c in lib.top_level() if c.bounding_box() is not None]
-                bbox_min = (min(b[0][0] for b in bboxes), min(b[0][1] for b in bboxes))
-                bbox_max = (max(b[1][0] for b in bboxes), max(b[1][1] for b in bboxes))
+                bbox = db.Box()
+                for cell in top_cells:
+                    bbox += cell.bbox()
+                bbox_min = (bbox.left * dbu, bbox.bottom * dbu)
+                bbox_max = (bbox.right * dbu, bbox.top * dbu)
 
             # Create collection for imported layers
             collection = None
@@ -734,14 +780,6 @@ class ImportGDSII(bpy.types.Operator, ImportHelper):
             print(f"Using PDK: {pdk_selection}")
             print(f"Layer stack config: {yamlfile}")
 
-            # Merge layers upfront with KLayout if requested
-            tmp_dir = None
-            gds_path = filepath
-            if self.merge_layers:
-                tmp_dir = tempfile.mkdtemp()
-                gds_path = str(_create_merged_gds(filepath, layerstack, tmp_dir))
-                print(f"Merged GDS written to: {gds_path}")
-
             # Import each layer from the stack
             imported_count = 0
             for layer_name, data in layerstack.items():
@@ -758,7 +796,8 @@ class ImportGDSII(bpy.types.Operator, ImportHelper):
                     layer_cfg = color_file.get('materials', {}).get(layer_cfg, {})
                 obj = create_extruded_layer(
                     self.report,
-                    gds_path,
+                    gds_layout,
+                    top_cells,
                     z,
                     height,
                     layer_index,
@@ -768,14 +807,11 @@ class ImportGDSII(bpy.types.Operator, ImportHelper):
                     unit=self.unit_scale,
                     crop_box=crop_box,
                     offset=crop_offset,
+                    merge=self.merge_layers,
                 )
 
                 if obj is not None:
                     imported_count += 1
-
-            if tmp_dir:
-                import shutil
-                shutil.rmtree(tmp_dir, ignore_errors=True)
 
             self.report({'INFO'}, f"Imported {imported_count} layers from {Path(filepath).name}")
             print(f"✓ Import complete! {imported_count} layers imported.")

--- a/scripts/build_extension.py
+++ b/scripts/build_extension.py
@@ -26,7 +26,7 @@ ADDON_DIR = REPO_DIR / "import_gdsii"
 WHEELS_DIR = ADDON_DIR / "wheels"
 MANIFEST_PATH = ADDON_DIR / "blender_manifest.toml"
 
-PACKAGES = ["gdstk", "klayout", "PyYAML"]
+PACKAGES = ["klayout", "PyYAML"]
 
 # Blender 4.2/4.3 uses Python 3.11, Blender 4.4+ uses Python 3.13.
 # Downloading wheels for both ensures compatibility across all supported versions.


### PR DESCRIPTION
> [!IMPORTANT]
> Based on #43 — please merge that one first. GitHub will retarget this PR to
> `main` automatically once it is merged.

Supersedes #40 by @Gerard-Taulats with the open review feedback addressed and a
cleaned up history. The importer commit keeps his authorship.

## What it does

GDS files are read with KLayout only, following the discussion in #40. The
layout is read **once** per import instead of once per layer, and every layer is
collected from all top cells with a recursive shape iterator. That resolves the
cell hierarchy on the fly, so the temporary merged GDS in `/tmp` is gone
together with the round trip of writing and re-reading it. `Merge Layers` now
merges the region in memory.

Polygons with holes cannot be expressed as a Blender n-gon, so KLayout
triangulates those and the vertices are welded with numpy. Hole-free polygons
are handed to Blender as they are. Both are triangulated, joined into quads
where possible and then extruded, which gives a much better topology than the
previous fan of quads per polygon.

With gdstk gone, the extension bundles one dependency less: three wheels fewer
per release.

## Changes on top of #40

* `reconstruct_layer` replaces `create_extruded_layer` instead of living next to
  it, so there is one import path and no `Merge Layers` mode that silently
  imports nothing.
* Shared materials (#36) work again — the new function takes `mat_name` and
  falls back to the layer name.
* Layers are read from the layout that is already in memory. The old
  `reconstruct_layer` re-read the GDS for every layer and only looked at shapes
  placed directly in the top cell, so it depended on the pre-merged file to see
  anything from sub cells.
* The redundant second `merge()` is gone. With `Merge Layers` off the region now
  keeps the polygons as drawn, since KLayout applies merged semantics to every
  operation unless it is told not to.
* The crop box rounds outwards (floor/ceil) instead of truncating towards zero,
  and the crop offset is applied to all polygons in database units. It was
  applied to hole-free polygons only, and in µm on integer coordinates, which
  raised a numpy casting error as soon as a crop was used.
* Degenerate triangles are dropped, `mesh.validate()` reports geometry Blender
  had to repair, and a layer above one million vertices warns in the UI.
* Face normals are recalculated after the extrusion, and the temporary second
  mesh with the duplicated name is gone.

## Testing

Blender 4.3.2, against a generated layout with overlapping shapes, a polygon
with a hole and geometry inside a sub cell:

* hierarchy is imported without the merged GDS, holes stay open, `Merge Layers`
  on/off differ as expected, cropping keeps the geometry at the origin
* every face references distinct vertices, bottom faces point down, top faces up
* shared materials, custom configs and the PDK presets from #43 still import

Import times are on par with the gdstk importer: 8.28s → 8.65s for 512k shapes
on five layers, 0.68s → 0.78s for 42k shapes. The gain here is the topology and
the hierarchy handling, not raw speed.

**Still to check with a real design:** the `create_extruded_layer` bug you hit
with the IHP padframe. I could not reproduce it with generated geometry, so it
would be good to confirm the new path renders that file correctly.
